### PR TITLE
Feat: 관심 분야 선택란 컴포넌트 구현

### DIFF
--- a/client/src/atom/atom.js
+++ b/client/src/atom/atom.js
@@ -38,6 +38,12 @@ export const endDateState = atom({
   default: null,
 });
 
+// 선택된 관심 분야 상태
+export const selectedInterestsState = atom({
+  key: 'selectedInterestState',
+  default: [],
+});
+
 // 사용자의 관심 분야 목록 상태
 export const interestViewState = atom({
   key: 'interestViewState',

--- a/client/src/components/InterestSelect.js
+++ b/client/src/components/InterestSelect.js
@@ -1,0 +1,140 @@
+/* eslint-disable no-unused-vars */
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+import { selectedInterestsState } from '../atom/atom';
+import { RiDeleteBack2Fill } from 'react-icons/ri';
+
+const interestList = [
+  '금융',
+  '제조',
+  '에너지/친환경',
+  '유통/물류',
+  '미디어',
+  '의료/헬스 케어',
+  '건설',
+  '교육',
+  '기타',
+];
+
+const InterestSelectWrapper = styled.div`
+  width: 100%;
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  border: 2px solid lightskyblue;
+
+  .selected-tag-list,
+  .tag-list {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .selected-tag-list {
+    margin-bottom: 10px;
+    border-bottom: 1px solid var(--purple-medium);
+  }
+
+  .tag-list {
+    margin-bottom: -10px;
+    overflow: hidden;
+  }
+`;
+
+const TagBtn = styled.button`
+  border: 1px solid var(--purple-medium);
+  border-radius: 25px;
+  background-color: white;
+  font-size: 15px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 0.5s;
+
+  display: flex;
+  align-items: center;
+  margin-right: 10px;
+  margin-bottom: 10px;
+  padding: 5px 15px;
+
+  &:hover {
+    border: 1px solid var(--purple);
+  }
+
+  &.selected-tag {
+    border: 1px solid var(--purple);
+    border-radius: 25px;
+    background-color: var(--purple);
+    color: white;
+  }
+
+  .delete-btn {
+    padding: 5px;
+    margin: -5px -5px -5px 0;
+    display: flex;
+    align-items: center;
+  }
+`;
+
+const Tag = ({ item, onClick, isSelected, onDelete }) => {
+  return (
+    <li>
+      <TagBtn onClick={onClick} className={isSelected ? 'selected-tag' : ''}>
+        {item}
+        {onDelete && (
+          <div
+            className="delete-btn"
+            onClick={() => onDelete(item)}
+            aria-hidden="true"
+          >
+            <RiDeleteBack2Fill />
+          </div>
+        )}
+      </TagBtn>
+    </li>
+  );
+};
+
+const InterestSelect = () => {
+  const [selectedInterests, setSelectedInterest] = useRecoilState(
+    selectedInterestsState,
+  );
+
+  const onDeleteClick = (selectedTag) => {
+    setSelectedInterest([
+      ...selectedInterests.filter((tag) => tag !== selectedTag),
+    ]);
+  };
+
+  const onTagClick = (e) => {
+    const selectedTag = e.target.textContent;
+    if (!selectedInterests.includes(selectedTag)) {
+      setSelectedInterest([...selectedInterests, selectedTag]);
+    }
+  };
+
+  return (
+    <InterestSelectWrapper>
+      <ul className="selected-tag-list">
+        {selectedInterests.map((item, idx) => (
+          <Tag
+            key={idx}
+            item={item}
+            onDelete={onDeleteClick}
+            isSelected={true}
+          ></Tag>
+        ))}
+      </ul>
+      <ul className="tag-list">
+        {interestList.map((item, idx) => (
+          <Tag
+            key={idx}
+            item={item}
+            onClick={onTagClick}
+            isSelected={selectedInterests.includes(item)}
+          />
+        ))}
+      </ul>
+    </InterestSelectWrapper>
+  );
+};
+
+export default InterestSelect;

--- a/client/src/components/InterestSelect.js
+++ b/client/src/components/InterestSelect.js
@@ -3,17 +3,28 @@ import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 import { selectedInterestsState } from '../atom/atom';
 import { RiDeleteBack2Fill } from 'react-icons/ri';
+import {
+  FcCurrencyExchange,
+  FcSupport,
+  FcFlashOn,
+  FcShipped,
+  FcVideoCall,
+  FcLike,
+  FcOrganization,
+  FcGraduationCap,
+  FcQuestions,
+} from 'react-icons/fc';
 
-const interestList = [
-  '금융',
-  '제조',
-  '에너지/친환경',
-  '유통/물류',
-  '미디어',
-  '의료/헬스 케어',
-  '건설',
-  '교육',
-  '기타',
+const interestContArr = [
+  { name: '금융', img: <FcCurrencyExchange className="interest-tag-img" /> },
+  { name: '제조', img: <FcSupport className="interest-tag-img" /> },
+  { name: '에너지/친환경', img: <FcFlashOn className="interest-tag-img" /> },
+  { name: '유통/물류', img: <FcShipped className="interest-tag-img" /> },
+  { name: '미디어', img: <FcVideoCall className="interest-tag-img" /> },
+  { name: '의료/헬스 케어', img: <FcLike className="interest-tag-img" /> },
+  { name: '건설', img: <FcOrganization className="interest-tag-img" /> },
+  { name: '교육', img: <FcGraduationCap className="interest-tag-img" /> },
+  { name: '기타', img: <FcQuestions className="interest-tag-img" /> },
 ];
 
 const InterestSelectWrapper = styled.div`
@@ -21,7 +32,6 @@ const InterestSelectWrapper = styled.div`
   height: auto;
   display: flex;
   flex-direction: column;
-  border: 2px solid lightskyblue;
 
   .selected-tag-list,
   .tag-list {
@@ -30,6 +40,7 @@ const InterestSelectWrapper = styled.div`
   }
 
   .selected-tag-list {
+    min-height: 52px;
     margin-bottom: 10px;
     border-bottom: 1px solid var(--purple-medium);
   }
@@ -38,6 +49,11 @@ const InterestSelectWrapper = styled.div`
     margin-bottom: -10px;
     overflow: hidden;
   }
+`;
+
+const TagList = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
 `;
 
 const TagBtn = styled.button`
@@ -53,7 +69,7 @@ const TagBtn = styled.button`
   align-items: center;
   margin-right: 10px;
   margin-bottom: 10px;
-  padding: 5px 15px;
+  padding: 7px 10px;
 
   &:hover {
     border: 1px solid var(--purple);
@@ -66,28 +82,33 @@ const TagBtn = styled.button`
     color: white;
   }
 
+  .interest-tag-img {
+    width: 20px;
+    height: 20px;
+
+    margin-right: 4px;
+    border-radius: 100%;
+    border: 2px solid white;
+    background-color: white;
+  }
+
   .delete-btn {
-    padding: 5px;
-    margin: -5px -5px -5px 0;
+    margin-left: 5px;
     display: flex;
     align-items: center;
+    order: 2;
   }
 `;
 
-const Tag = ({ item, onClick, isSelected, onDelete }) => {
+const Tag = ({ tag, onClick, isSelected, onDelete, icon }) => {
   return (
     <li>
-      <TagBtn onClick={onClick} className={isSelected ? 'selected-tag' : ''}>
-        {item}
-        {onDelete && (
-          <div
-            className="delete-btn"
-            onClick={() => onDelete(item)}
-            aria-hidden="true"
-          >
-            <RiDeleteBack2Fill />
-          </div>
-        )}
+      <TagBtn
+        onClick={() => (isSelected ? onDelete(tag) : onClick(tag))}
+        className={isSelected ? 'selected-tag' : ''}
+      >
+        {icon}
+        {tag}
       </TagBtn>
     </li>
   );
@@ -104,8 +125,7 @@ const InterestSelect = () => {
     ]);
   };
 
-  const onTagClick = (e) => {
-    const selectedTag = e.target.textContent;
+  const onTagClick = (selectedTag) => {
     if (!selectedInterests.includes(selectedTag)) {
       setSelectedInterest([...selectedInterests, selectedTag]);
     }
@@ -113,26 +133,29 @@ const InterestSelect = () => {
 
   return (
     <InterestSelectWrapper>
-      <ul className="selected-tag-list">
+      <TagList className="selected-tag-list">
         {selectedInterests.map((item, idx) => (
           <Tag
+            icon={<RiDeleteBack2Fill className="delete-btn" />}
             key={idx}
-            item={item}
+            tag={item}
             onDelete={onDeleteClick}
             isSelected={true}
           ></Tag>
         ))}
-      </ul>
-      <ul className="tag-list">
-        {interestList.map((item, idx) => (
+      </TagList>
+      <TagList className="tag-list">
+        {interestContArr.map((item, idx) => (
           <Tag
+            icon={item.img}
             key={idx}
-            item={item}
+            tag={item.name}
             onClick={onTagClick}
-            isSelected={selectedInterests.includes(item)}
+            onDelete={onDeleteClick}
+            isSelected={selectedInterests.includes(item.name)}
           />
         ))}
-      </ul>
+      </TagList>
     </InterestSelectWrapper>
   );
 };


### PR DESCRIPTION
 관심 분야 선택란 컴포넌트입니다! 
- 선택된 태그 목록은 selectedInterestsState라는 이름으로 전역 state로 만들어 두었습니다! 우선은 프론트에서 필요한 부분인 tag이름만 배열에 나열하도록 만들어서, 서버측에 보낼 때 형식을 맞춰주시거나 수정해서 사용해주시면 될 것 같습니다! 
- Tag를 파일 내 컴포넌트로 분리해 두었습니다! 
- 선택 해제시 클릭할 수 있는 범위가 더 넓으면 좋을 것 같아 태그 전체를 범위로 넓혔습니다!
- 사용성을 고려해 선택된 태그를 목록에서도 다시 클릭하면 해제할 수 있도록 했습니다!
- 페이지 내에서 위아래 마진을 설정하는 것이 편리할 것 같아 우선 위아래 마진은 0으로 해두었습니다.

변경이 필요한 부분이 있다면 부담 없이 변경해주세요~!!