### PR TITLE
Feat : 모집여부 토글스위치 구현

### DIFF
--- a/client/src/components/SwitchToggle.js
+++ b/client/src/components/SwitchToggle.js
@@ -2,36 +2,128 @@
 import styled from 'styled-components';
 
 const ToggleContainer = styled.div`
+  width: ${(props) => props.width ?? '100px'};
+  align-items: center;
+  justify-content: flex-start;
+  display: flex;
+  padding-left: 4px;
+  background-color: ${(props) =>
+    props.checked ? 'var(--purple)' : 'var(--purple-light)'};
+  border: solid 2px var(--purple);
+  border-radius: 20px;
+`;
+
+const CheckBoxContainer = styled.div`
+  display: flex;
   justify-content: center;
   align-items: center;
-  display: flex;
-  z-index: 0;
 `;
-
 const CheckBox = styled.input`
+  cursor: pointer;
+  /* z-index: 1; */
+  width: 0rem;
+  height: 2rem;
+  border: solid 2px var(--purple-medium);
+  border-radius: 20px;
+
   /* Not Checked => props로 받은 content(Text) (토글 왼쪽 위치) */
   ::before {
+    position: absolute;
+    content: '${(props) => props.left ?? '모집 중'}';
+    width: 5rem;
+    height: 2rem;
+    display: flex;
+    padding: 0 0 0 0.9em;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    color: var(--purple);
+    font-weight: 700;
+    font-size: 13px;
+    /* 텍스트 트랜지션 */
+    transition: all 0.2s ease-in-out;
   }
 
-  /* Not Checked => 빈 content를 block 형태로 생성 (토글 오른쪽 위치)*/
+  /* Not Checked => 빈 content를 block 형태로 생성한 원 (토글 오른쪽 위치)*/
   ::after {
+    position: relative;
+    content: '';
+    display: block;
+    width: 1.4em;
+    height: 1.4em;
+    top: calc((2rem - 1.3em) / 2);
+    left: calc(5.4rem - 2em);
+    border-radius: 50%;
+    background: var(--purple);
+    /* 원 이동 트랜지션 */
+    transition: all 0.2s ease-in-out;
   }
+  &:checked {
+    /* 배경색 변경 트랜지션 */
+    transition: all 0.2s ease-in-out;
 
-  /* Checked => props로 받은 content(Text) (토글 오른쪽 위치) */
-  ::before {
-  }
-  /* Checked => 빈 content를 block 형태로 생성 (토글의 왼쪽 위치) */
-  ::after {
+    /* Checked => props로 받은 content(Text) (토글 오른쪽 위치) */
+    ::before {
+      position: absolute;
+      padding: 0 0 0 1.2em;
+      content: '${(props) => props.right ?? '모집 완료'}';
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 13px;
+      color: white;
+    }
+
+    /* Checked => 빈 content를 block 형태로 생성한 원 (토글 왼쪽 위치) */
+    ::after {
+      content: '';
+      z-index: 1;
+      top: calc((2rem - 1.3em) / 2);
+      left: calc((1.8rem - 1.3em) / 2);
+      width: 1.4em;
+      height: 1.4em;
+      display: block;
+      position: relative;
+      background-color: white;
+      border-radius: 50%;
+    }
   }
 `;
 
-// 부모 컴포넌트로부터 props로 onChange 시 변경 값 전달할 함수,
-const SwitchToggle = () => {
+const SwitchToggle = ({ left, right, setChecked, onClick, width }) => {
   return (
-    <ToggleContainer>
-      <CheckBox></CheckBox>
+    <ToggleContainer checked={!setChecked} width={width}>
+      <CheckBoxContainer>
+        <CheckBox
+          left={left}
+          right={right}
+          onChange={() => {}}
+          value=""
+          checked={!setChecked}
+          type="checkbox"
+          onClick={onClick}
+        ></CheckBox>
+      </CheckBoxContainer>
     </ToggleContainer>
   );
 };
 
 export default SwitchToggle;
+
+// 부모 컴포넌트 예시입니다. 추후 삭제 할 예정입니다.
+// export const ParentComponents = () => {
+//   const [ischeck, setIsCheck] = useState(true);
+//   return (
+//     <div>
+//       <SwitchToggle
+//         left="모집 중"
+//         right="모집 완료"
+//         setChecked={ischeck}
+//         onClick={() => {
+//           setIsCheck(!ischeck);
+//         }}
+//         width="100px"
+//       />
+//     </div>
+//   );
+// };

--- a/client/src/components/SwitchToggle.js
+++ b/client/src/components/SwitchToggle.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import styled from 'styled-components';
 
 const ToggleContainer = styled.div`
@@ -90,16 +89,14 @@ const CheckBox = styled.input`
   }
 `;
 
-const SwitchToggle = ({ left, right, setChecked, onClick, width }) => {
+const SwitchToggle = ({ right, setChecked, onClick }) => {
   return (
-    <ToggleContainer checked={!setChecked} width={width}>
+    <ToggleContainer checked={!setChecked} width="100px">
       <CheckBoxContainer>
         <CheckBox
-          left={left}
+          left="모집 중"
           right={right}
-          onChange={() => {}}
           value=""
-          checked={!setChecked}
           type="checkbox"
           onClick={onClick}
         ></CheckBox>
@@ -112,15 +109,14 @@ export default SwitchToggle;
 
 // 부모 컴포넌트 예시입니다. 추후 삭제 할 예정입니다.
 // export const ParentComponents = () => {
-//   const [ischeck, setIsCheck] = useState(true);
+//   const [isCheck, setIsCheck] = useState(true);
 //   return (
 //     <div>
 //       <SwitchToggle
-//         left="모집 중"
 //         right="모집 완료"
-//         setChecked={ischeck}
+//         setChecked={isCheck}
 //         onClick={() => {
-//           setIsCheck(!ischeck);
+//           setIsCheck(!isCheck);
 //         }}
 //         width="100px"
 //       />

--- a/client/src/components/SwitchToggle.js
+++ b/client/src/components/SwitchToggle.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-unused-vars */
+import styled from 'styled-components';
+
+const ToggleContainer = styled.div`
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  z-index: 0;
+`;
+
+const CheckBox = styled.input`
+  /* Not Checked => props로 받은 content(Text) (토글 왼쪽 위치) */
+  ::before {
+  }
+
+  /* Not Checked => 빈 content를 block 형태로 생성 (토글 오른쪽 위치)*/
+  ::after {
+  }
+
+  /* Checked => props로 받은 content(Text) (토글 오른쪽 위치) */
+  ::before {
+  }
+  /* Checked => 빈 content를 block 형태로 생성 (토글의 왼쪽 위치) */
+  ::after {
+  }
+`;
+
+// 부모 컴포넌트로부터 props로 onChange 시 변경 값 전달할 함수,
+const SwitchToggle = () => {
+  return (
+    <ToggleContainer>
+      <CheckBox></CheckBox>
+    </ToggleContainer>
+  );
+};
+
+export default SwitchToggle;


### PR DESCRIPTION
메인페이지와 게시글 수정/상세보기에서 사용할 모집여부 스위치 구현입니다.
props로 넘겨주셔야 할 값은 하기와 같습니다.

1. left (왼쪽 텍스트 => 토글 버튼은 오른쪽으로 갑니다) : 모집 중 
   ✅ 고정 값으로 사용하면 될 것 같아서 고정 값으로 넣어 두는 것으로 변경하였습니다.
        혹시 바꾸실 일이 있다면 수정해서 사용해주세요!
2. right (오른쪽 텍스트 => 토글 버튼은 왼쪽으로 갑니다)  : 모집 완료  혹은 전체 보기
   ( 필요하신 문구로 사용 해주세요 ☺️) 
3. 체크 여부 상태(불리언 타입)
4. 온클릭 이벤트 (체크 상태 반전)
예시) onClick={ ( ) => {setIsCheck(!ischeck) }}
5. width 
    ✅ 레이아웃이 틀어질 것 같아서 100px 고정 값으로 사용을 권장 드립니다. 
    우선 고정값으로 두었는데 혹시 바꾸실 일이 있다면 수정해서 사용해주세요!
        
컴포넌트 최하단에 아래 사진처럼 부모 컴포넌트 예시를 주석으로 달아 두었으니 참고 부탁드립니다!
글 내용이 함께 바뀌는 토글이 처음이라ㅜㅜ 혹시 코드에 수정이 필요하시면 얼마든지 수정해서 사용해주세요!
또 더 좋은 아이디어가 있으시다면 언제든 피드백 주세요!

<img width="501" alt="스크린샷 2022-11-19 오전 1 33 39" src="https://user-images.githubusercontent.com/95066637/202764587-880d4737-a900-4d44-ad19-b4347466b294.png">

