### PR TITLE
refactor: 기술스택 선택란 리팩토링 

### DIFF
--- a/client/src/atom/atom.js
+++ b/client/src/atom/atom.js
@@ -9,8 +9,8 @@ export const activeIdxState = atom({
 });
 
 // 선택 or 입력된 기술 스택 목록 상태
-export const selectedSkillStacksState = atom({
-  key: 'selectedSkillStacksState',
+export const selectedSkillstacksState = atom({
+  key: 'selectedSkillstacksState',
   default: [],
 });
 

--- a/client/src/atom/atom.js
+++ b/client/src/atom/atom.js
@@ -9,8 +9,8 @@ export const activeIdxState = atom({
 });
 
 // 선택 or 입력된 기술 스택 목록 상태
-export const selectedTagsState = atom({
-  key: 'selectedTagsState',
+export const selectedSkillStacksState = atom({
+  key: 'selectedSkillStacksState',
   default: [],
 });
 

--- a/client/src/components/SkillStackSelect.js
+++ b/client/src/components/SkillStackSelect.js
@@ -1,6 +1,7 @@
-import styled from 'styled-components';
 import { useRecoilState } from 'recoil';
-import { activeIdxState, selectedSkillStacksState } from '../atom/atom';
+import styled from 'styled-components';
+import { activeIdxState, selectedSkillstacksState } from '../atom/atom';
+import { RiDeleteBack2Fill } from 'react-icons/ri';
 import {
   SiJavascript,
   SiTypescript,
@@ -22,18 +23,31 @@ import {
   SiGraphql,
   SiFirebase,
 } from 'react-icons/si';
-import { RiDeleteBack2Fill } from 'react-icons/ri';
 
-const Container = styled.div`
-  color: var(--grey-dark);
-  font-size: 15px;
+const InterestSelectWrapper = styled.div`
   width: 100%;
   height: auto;
-  min-width: 250px;
+  display: flex;
+  flex-direction: column;
+
+  .selected-tag-list,
+  .tag-list {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .selected-tag-list {
+    min-height: 52px;
+  }
+
+  .tag-list {
+    margin-bottom: -10px;
+    overflow: hidden;
+  }
 
   .tab-menu {
     border-bottom: 1px solid var(--purple-medium);
-    height: 50px; // 수정
+    margin-bottom: 10px;
 
     display: flex;
     flex-direction: row;
@@ -43,6 +57,7 @@ const Container = styled.div`
 
   .tab-title {
     cursor: pointer;
+    font-size: 15px;
 
     width: 100% auto;
     height: 100%;
@@ -57,256 +72,249 @@ const Container = styled.div`
     color: var(--purple);
     border-bottom: 3px solid var(--purple);
   }
+`;
 
-  .tab-content {
-    display: flex;
-    flex-wrap: wrap;
+const Input = styled.input`
+  width: 100%;
+  height: 30px;
+  padding: 8px 8px 10px;
+  margin: 10px 10px;
+  border-radius: 8px;
+  border: none;
+  color: var(--black);
+  outline: none;
+  border: 1px solid var(--purple-medium);
+  transition: 300ms ease-in-out;
+  white-space: nowrap;
+  line-height: 0;
+
+  &:hover,
+  &:focus,
+  &:active {
+    border-color: var(--purple);
   }
 
-  .skill-tag {
-    border: 1px solid var(--purple-medium);
-    border-radius: 25px;
-    background-color: white;
-    font-size: 15px;
-    cursor: pointer;
-
-    display: flex;
-    align-items: center;
-    margin: 15px 15px 15px 0;
-    padding: 7px 10px;
+  &:focus,
+  &:active {
+    box-shadow: 0px 0px 0px 4px var(--purple-medium);
   }
+`;
 
-  .skill-tag:hover {
+const TagList = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+`;
+
+const TagBtn = styled.button`
+  border: 1px solid var(--purple-medium);
+  border-radius: 25px;
+  background-color: white;
+  font-size: 15px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 0.5s;
+  display: flex;
+  align-items: center;
+  margin-right: 10px;
+  margin-bottom: 10px;
+  padding: 7px 10px;
+
+  &:hover {
     border: 1px solid var(--purple);
-
-    transition: all 0.5s;
   }
 
-  .skill-tag-img {
+  &.selected-tag {
+    border: 1px solid var(--purple);
+    border-radius: 25px;
+    background-color: var(--purple);
+    color: white;
+  }
+
+  .interest-tag-img {
     width: 20px;
     height: 20px;
-
-    margin-right: 6px;
+    margin-right: 4px;
     border-radius: 100%;
     border: 2px solid white;
     background-color: white;
   }
 
-  .skill-tag-input {
-    border: 1px solid var(--purple-medium);
-    border-radius: 8px;
-    width: 100%;
-    height: 30px;
-    margin: 15px 15px;
-    padding: 8px 10px;
-  }
-
-  .skill-tag-input:focus {
-    outline: 4px solid var(--purple-medium);
-    border: 1px solid var(--purple);
-  }
-
-  .selected-tags {
-    width: 100%;
-  }
-
-  .selected-tags > ul {
-    min-height: 67px;
-    display: flex;
-    flex-wrap: wrap;
-  }
-
-  .skill-selected-tag {
-    border: 1px solid var(--purple);
-    border-radius: 25px;
-    background-color: var(--purple);
-    color: white;
-    cursor: pointer;
-
+  .delete-btn {
+    margin-left: 5px;
     display: flex;
     align-items: center;
-    margin: 15px 15px 15px 0;
-    padding: 7px 10px;
-  }
-
-  .skill-selected-tag > .delete {
-    margin: 2px 0 0 5px;
-    display: flex;
-    align-items: center;
+    order: 2;
   }
 `;
 
-function SkillStackSelect() {
-  const [activeIdx, setActiveIdx] = useRecoilState(activeIdxState);
-  const [selectedTags, setSelectedTags] = useRecoilState(
-    selectedSkillStacksState,
-  );
+const tabContArr = [
+  {
+    tabTitle: '프론트엔드',
+    tabCont: [
+      {
+        name: 'JavaScript',
+        img: <SiJavascript className="interest-tag-img" color="#F7DF1E" />,
+      },
+      {
+        name: 'TypeScript',
+        img: <SiTypescript className="interest-tag-img" color="#3178C6" />,
+      },
+      {
+        name: 'React',
+        img: <SiReact className="interest-tag-img" color="#61DAFB" />,
+      },
+      {
+        name: 'Vue',
+        img: <SiVuedotjs className="interest-tag-img" color="#4FC08D" />,
+      },
+      {
+        name: 'Svelte',
+        img: <SiSvelte className="interest-tag-img" color="#FF3E00" />,
+      },
+      {
+        name: 'Nextjs',
+        img: <SiNextdotjs className="interest-tag-img" color="#000000" />,
+      },
+    ],
+  },
+  {
+    tabTitle: '백엔드',
+    tabCont: [
+      {
+        name: 'Java',
+        img: <SiJava className="interest-tag-img" color="#000000" />,
+      },
+      {
+        name: 'Spring',
+        img: <SiSpring className="interest-tag-img" color="#6DB33F" />,
+      },
+      {
+        name: 'Nodejs',
+        img: <SiNodedotjs className="interest-tag-img" color="#339933" />,
+      },
+      {
+        name: 'Nextjs',
+        img: <SiNextdotjs className="interest-tag-img" color="#000000" />,
+      },
+      {
+        name: 'Go',
+        img: <SiGo className="interest-tag-img" color="#00ADD8" />,
+      },
+      {
+        name: 'Kotlin',
+        img: <SiKotlin className="interest-tag-img" color="#FE8901" />,
+      },
+      {
+        name: 'Express',
+        img: <SiExpress className="interest-tag-img" color="#000000" />,
+      },
+      {
+        name: 'MySQL',
+        img: <SiMysql className="interest-tag-img" color="#4479A1" />,
+      },
+      {
+        name: 'MongoDB',
+        img: <SiMongodb className="interest-tag-img" color="#47A248" />,
+      },
+      {
+        name: 'Python',
+        img: <SiPython className="interest-tag-img" color="#3776AB" />,
+      },
+      {
+        name: 'Django',
+        img: <SiDjango className="interest-tag-img" color="#092E20" />,
+      },
+      {
+        name: 'php',
+        img: <SiPhp className="interest-tag-img" color="#777BB4" />,
+      },
+      {
+        name: 'GraphQL',
+        img: <SiGraphql className="interest-tag-img" color="#E10098" />,
+      },
+      {
+        name: 'Firebase',
+        img: <SiFirebase className="interest-tag-img" color="#FFCA28" />,
+      },
+    ],
+  },
+  {
+    tabTitle: '기타',
+    tabCont: [],
+  },
+];
 
-  const tabContArr = [
-    {
-      tabTitle: '프론트엔드',
-      tabCont: [
-        {
-          name: 'JavaScript',
-          img: <SiJavascript className="skill-tag-img" color="#F7DF1E" />,
-        },
-        {
-          name: 'TypeScript',
-          img: <SiTypescript className="skill-tag-img" color="#3178C6" />,
-        },
-        {
-          name: 'React',
-          img: <SiReact className="skill-tag-img" color="#61DAFB" />,
-        },
-        {
-          name: 'Vue',
-          img: <SiVuedotjs className="skill-tag-img" color="#4FC08D" />,
-        },
-        {
-          name: 'Svelte',
-          img: <SiSvelte className="skill-tag-img" color="#FF3E00" />,
-        },
-        {
-          name: 'Nextjs',
-          img: <SiNextdotjs className="skill-tag-img" color="#000000" />,
-        },
-      ],
-    },
-    {
-      tabTitle: '백엔드',
-      tabCont: [
-        {
-          name: 'Java',
-          img: <SiJava className="skill-tag-img" color="#000000" />,
-        },
-        {
-          name: 'Spring',
-          img: <SiSpring className="skill-tag-img" color="#6DB33F" />,
-        },
-        {
-          name: 'Nodejs',
-          img: <SiNodedotjs className="skill-tag-img" color="#339933" />,
-        },
-        {
-          name: 'Nextjs',
-          img: <SiNextdotjs className="skill-tag-img" color="#000000" />,
-        },
-        { name: 'Go', img: <SiGo className="skill-tag-img" color="#00ADD8" /> },
-        {
-          name: 'Kotlin',
-          img: <SiKotlin className="skill-tag-img" color="#FE8901" />,
-        },
-        {
-          name: 'Express',
-          img: <SiExpress className="skill-tag-img" color="#000000" />,
-        },
-        {
-          name: 'MySQL',
-          img: <SiMysql className="skill-tag-img" color="#4479A1" />,
-        },
-        {
-          name: 'MongoDB',
-          img: <SiMongodb className="skill-tag-img" color="#47A248" />,
-        },
-        {
-          name: 'Python',
-          img: <SiPython className="skill-tag-img" color="#3776AB" />,
-        },
-        {
-          name: 'Django',
-          img: <SiDjango className="skill-tag-img" color="#092E20" />,
-        },
-        {
-          name: 'php',
-          img: <SiPhp className="skill-tag-img" color="#777BB4" />,
-        },
-        {
-          name: 'GraphQL',
-          img: <SiGraphql className="skill-tag-img" color="#E10098" />,
-        },
-        {
-          name: 'Firebase',
-          img: <SiFirebase className="skill-tag-img" color="#FFCA28" />,
-        },
-      ],
-    },
-    {
-      tabTitle: '기타',
-      tabCont: [],
-    },
-  ];
+const Tag = ({ tag, onClick, isSelected, onDelete, icon }) => {
+  return (
+    <li>
+      <TagBtn
+        onClick={() => (isSelected ? onDelete(tag) : onClick(tag))}
+        className={isSelected ? 'selected-tag' : ''}
+      >
+        {icon}
+        {tag}
+      </TagBtn>
+    </li>
+  );
+};
+
+const SkillStackSelect = () => {
+  const [activeIdx, setActiveIdx] = useRecoilState(activeIdxState);
+  const [selectedSkillstacks, setSelectedSkillstacks] = useRecoilState(
+    selectedSkillstacksState,
+  );
 
   const onTabClick = (index) => {
     setActiveIdx(index); // 클릭한 탭으로 활성화 탭 변경
   };
 
+  const onDeleteClick = (selectedTag) => {
+    setSelectedSkillstacks([
+      ...selectedSkillstacks.filter((tag) => tag !== selectedTag),
+    ]);
+  };
+
+  const onTagClick = (selectedTag) => {
+    if (!selectedSkillstacks.includes(selectedTag)) {
+      setSelectedSkillstacks([...selectedSkillstacks, selectedTag]);
+    }
+  };
+
   const onInputKeyUp = (e) => {
-    const filterTarget = selectedTags.filter(
-      (el) => el.skillName === e.target.value,
+    const duplicateCheck = selectedSkillstacks.filter(
+      (el) => el === e.target.value,
     );
-    // 중복 확인 위한 arr(중복X:null, 중복:값O)
+    // 중복 확인 위한 arr(중복X: null, 중복: 값O)
 
     if (
       e.key === 'Enter' &&
-      filterTarget.length === 0 &&
+      duplicateCheck.length === 0 &&
       e.target.value.length > 0
     ) {
-      let tagObj = {};
-      tagObj.skillName = e.target.value;
-      setSelectedTags([...selectedTags, tagObj]); // 태그가 추가된 arr를 선택태그리스트 값으로 재설정
+      let newSkillName = e.target.value;
+      setSelectedSkillstacks([...selectedSkillstacks, newSkillName]); // 태그가 추가된 arr를 선택태그리스트 값으로 재설정
       e.target.value = '';
     } else if (
-      filterTarget.length !== 0 &&
+      duplicateCheck.length !== 0 &&
       e.key === 'Enter' // 중복 태그 시
     ) {
       e.target.value = '';
     }
   };
 
-  const onDeleteClick = (index) => {
-    const filtered = selectedTags.filter((el, idx) => idx !== index);
-    setSelectedTags(filtered);
-  };
-
-  const onTagClick = (e) => {
-    const filterTarget = selectedTags.filter(
-      (el) => el.skillName === e.target.textContent,
-    );
-
-    if (filterTarget.length === 0) {
-      let tagObj = {};
-      tagObj.skillName = e.target.textContent;
-      setSelectedTags([...selectedTags, tagObj]);
-    } else if (
-      filterTarget.length !== 0 // 중복 태그 시
-    ) {
-      {
-        ('');
-      }
-    }
-  };
-
   return (
-    <Container>
-      <div className="selected-tags">
-        <ul>
-          {
-            // 선택, 입력된 태그들 표시
-            selectedTags.map((tag, idx) => (
-              <li key={idx} className="skill-selected-tag">
-                <div>{tag.skillName}</div>
-                <div
-                  className="delete"
-                  onClick={() => onDeleteClick(idx)}
-                  aria-hidden="true"
-                >
-                  <RiDeleteBack2Fill />
-                </div>
-              </li>
-            ))
-          }
-        </ul>
-      </div>
+    <InterestSelectWrapper>
+      <TagList className="selected-tag-list">
+        {selectedSkillstacks.map((item, idx) => (
+          <Tag
+            icon={<RiDeleteBack2Fill className="delete-btn" />}
+            key={idx}
+            tag={item}
+            onDelete={onDeleteClick}
+            isSelected={true}
+          ></Tag>
+        ))}
+      </TagList>
       <ul className="tab-menu">
         {tabContArr.map((section, idx) => {
           return (
@@ -322,39 +330,28 @@ function SkillStackSelect() {
           );
         })}
       </ul>
-      <div className="tab-content">
-        {
-          // 기타 직접 입력
-          activeIdx === 2 ? (
-            <input
-              className="skill-tag-input"
-              placeholder="기술 태그를 직접 입력해주세요."
-              onKeyUp={onInputKeyUp}
-            ></input>
-          ) : (
-            // FE, BE 선택 입력
-            tabContArr[activeIdx].tabCont.map((skillTag, idx) => {
-              return (
-                <button
-                  key={idx}
-                  className={
-                    selectedTags.filter((el) => el.skillName === skillTag.name)
-                      .length !== 0
-                      ? 'skill-tag skill-selected-tag'
-                      : 'skill-tag'
-                  }
-                  onClick={onTagClick}
-                >
-                  {skillTag.img}
-                  {skillTag.name}
-                </button>
-              );
-            })
-          )
-        }
-      </div>
-    </Container>
+      <TagList className="tag-list">
+        {activeIdx === 2 ? (
+          <Input
+            className="skill-tag-input"
+            placeholder="기술 태그를 직접 입력해주세요."
+            onKeyUp={onInputKeyUp}
+          ></Input>
+        ) : (
+          tabContArr[activeIdx].tabCont.map((item, idx) => (
+            <Tag
+              icon={item.img}
+              key={idx}
+              tag={item.name}
+              onClick={onTagClick}
+              onDelete={onDeleteClick}
+              isSelected={selectedSkillstacks.includes(item.name)}
+            />
+          ))
+        )}
+      </TagList>
+    </InterestSelectWrapper>
   );
-}
+};
 
 export default SkillStackSelect;

--- a/client/src/components/SkillStackSelect.js
+++ b/client/src/components/SkillStackSelect.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { useRecoilState } from 'recoil';
-import { activeIdxState, selectedTagsState } from '../atom/atom';
+import { activeIdxState, selectedSkillStacksState } from '../atom/atom';
 import {
   SiJavascript,
   SiTypescript,
@@ -138,7 +138,9 @@ const Container = styled.div`
 
 function SkillStackSelect() {
   const [activeIdx, setActiveIdx] = useRecoilState(activeIdxState);
-  const [selectedTags, setSelectedTags] = useRecoilState(selectedTagsState);
+  const [selectedTags, setSelectedTags] = useRecoilState(
+    selectedSkillStacksState,
+  );
 
   const tabContArr = [
     {


### PR DESCRIPTION
#56 기술 스택 선택란 컴포넌트 리팩토링입니다.

- 선택된 태그 목록은 selectedSkillstacksState라는 이름으로 전역 state로 만들어 두었습니다! 
   우선은 프론트에서 필요한 부분인 tag이름만 배열에 나열하도록 만들어서, 
   서버 측에 보낼 때 형식을 맞춰 수정해 사용해야 할 것 같습니다!

   서버 측에 보낼 때 형식에 맞춰 수정할 코드 예시
   :`새로운 변수 이름 = 배열로 이름만 담은 변수.map((el) => return {skillName : el})`

- Tag를 파일 내 컴포넌트로 분리, 
   사용성을 고려해 선택된 태그를 목록에서도 다시 클릭하면 해제할 수 있도록 구현, 
   페이지 내에서 위아래 마진을 설정하는 것이 편리할 것 같아 우선 위아래 마진은 0으로 설정
   등의 관심분야 선택란의 코드 로직과 같도록 리팩토링 하였습니다.
   
- 원래는 서버로 바로 보내기 위해 선택된 태그를 state로 저장할 때 {skillName : 태그}로 저장했었지만, 
   이렇게 코드를 작성했을 때의 이미지 클릭 버그를 해결할 수 없을 것 같아 수정했습니다. 
   또, 태그를 재클릭 했을 때 해제까지 가능한 점이 사용자의 사용성을 고려했을 때 더욱 좋을 것 같아 로직을 수정해 리팩토링 했습니다.
   
    
**코드가 많이 바뀌어서 코드를 확인하실 때, 
Files Changed 클릭 > 해당 파일이름이 나와있는 줄의 우측에 있는 viewed옆 ... 클릭 > view file 로 보시는 것이 편할 것 같아요!**