### PR TITLE
feat: 마이페이지 구현

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -49,5 +49,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.10",
     "eslint-plugin-react-hooks": "^4.6.0"
-  }
+  },
+  "proxy": "http://ec2-15-165-2-129.ap-northeast-2.compute.amazonaws.com:8080"
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,26 +10,35 @@ import Profile from './pages/Profile';
 import SignUp from './pages/SignUp';
 import styled from 'styled-components';
 
-const HeaderContainer = styled.div`
-  height: 62px;
+const Container = styled.div`
+  background-color: var(--purple-light);
+`;
+
+const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  margin: 0 170px;
 `;
 
 function App() {
   return (
     <>
-      <HeaderContainer>
+      <Container>
         <Header />
-      </HeaderContainer>
-      <Routes>
-        <Route path="/" element={<Main />} />
-        <Route path="/write" element={<ArticleWrite />} />
-        <Route path="/article/edit/:id" element={<ArticleEdit />} />
-        <Route path="/article/:id" element={<ArticleDetail />} />
-        <Route path="/mypage/:id" element={<MyPage />} />
-        <Route path="/mypage/edit/:id" element={<MyPageEdit />} />
-        <Route path="/profile" element={<Profile />} />
-        <Route path="/signup" element={<SignUp />} />
-      </Routes>
+        <ContentContainer>
+          <Routes>
+            <Route path="/" element={<Main />} />
+            <Route path="/write" element={<ArticleWrite />} />
+            <Route path="/article/edit/:id" element={<ArticleEdit />} />
+            <Route path="/article/:id" element={<ArticleDetail />} />
+            <Route path="/mypage/:id" element={<MyPage />} />
+            <Route path="/mypage/edit/:id" element={<MyPageEdit />} />
+            <Route path="/profile" element={<Profile />} />
+            <Route path="/signup" element={<SignUp />} />
+          </Routes>
+        </ContentContainer>
+      </Container>
     </>
   );
 }

--- a/client/src/atom/atom.js
+++ b/client/src/atom/atom.js
@@ -52,16 +52,7 @@ export const selectedInterestsState = atom({
 // 사용자의 관심 분야 목록 상태
 export const interestViewState = atom({
   key: 'interestViewState',
-  default: [
-    {
-      interestId: 1,
-      name: '교육',
-    },
-    {
-      interestId: 2,
-      name: '에너지/친환경',
-    },
-  ],
+  default: [],
 });
 
 // 사용자의 기술 스택 목록 상태
@@ -70,27 +61,15 @@ export const skillStackViewState = atom({
   default: [
     {
       tabTitle: '프론트엔드',
-      tabCont: [
-        {
-          skillId: 1,
-          name: 'JavaScript',
-        },
-        {
-          skillId: 2,
-          name: 'TypeScript',
-        },
-      ],
+      tabCont: [],
     },
     {
       tabTitle: '백엔드',
-      tabCont: [
-        { skillId: 1, name: 'Java' },
-        { skillId: 2, name: 'MongoDB' },
-      ],
+      tabCont: [],
     },
     {
       tabTitle: '기타',
-      tabCont: [{ skillId: 1, name: 'Figma' }],
+      tabCont: [],
     },
   ],
 });
@@ -98,15 +77,7 @@ export const skillStackViewState = atom({
 // 유저 프로필 기본 정보
 export const userProfileState = atom({
   key: 'userProfileState',
-  default: {
-    memberId: 1,
-    email: 'hgd@gmail.com',
-    password: 'hgd1234!',
-    name: '홍길동',
-    description: '길동이입니다',
-    level: '학생',
-    github: 'github.com/honggildong',
-  },
+  default: {},
 });
 
 // 로그인된 유저의 정보 (유저 아이디)
@@ -126,5 +97,17 @@ export const inputBodyState = atom({
 // 입력된 해시태그 목록 상태
 export const inputHashTagsState = atom({
   key: 'inputHashTagsState',
+  default: [],
+});
+
+// 사용자가 모집한 프로젝트 목록 상태
+export const recruitedArticlesState = atom({
+  key: 'recruitedArticlesState',
+  default: [],
+});
+
+// 사용자가 좋아요한 프로젝트 목록 상태
+export const likedArticlesState = atom({
+  key: 'likedArticlesState',
   default: [],
 });

--- a/client/src/components/ArticleCard.js
+++ b/client/src/components/ArticleCard.js
@@ -169,7 +169,7 @@ const ArticleCard = ({
 }) => {
   return (
     <ArticleCardWrapper
-      to={articleId}
+      to={`/articles/${articleId}`}
       className={isCompleted === false ? '' : 'closed'}
     >
       <article>

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -4,12 +4,16 @@ import { BiMoon } from 'react-icons/bi';
 import { useState } from 'react';
 
 const HeaderContainer = styled.header`
+  z-index: 1;
   width: 100%;
   height: 62px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  position: fixed;
+  position: sticky;
+  top: 0;
+  right: 0;
+  left: 0;
 
   .header-container {
     width: 100%;
@@ -36,6 +40,7 @@ const HeaderContainer = styled.header`
     padding-right: 132px;
   }
   .logo {
+    white-space: nowrap;
     padding-right: 50px;
     padding-left: 170px;
     font-size: 25px;
@@ -47,6 +52,7 @@ const HeaderContainer = styled.header`
     font-size: 15px;
 
     li {
+      white-space: nowrap;
       list-style: none;
       margin-right: 31px;
       width: auto;

--- a/client/src/components/InterestView.js
+++ b/client/src/components/InterestView.js
@@ -14,7 +14,6 @@ import {
 } from 'react-icons/fc';
 
 const Container = styled.div`
-  border: 1px solid red;
   width: 100%;
   color: var(--black);
   font-size: 15px;

--- a/client/src/components/SkillStackView.js
+++ b/client/src/components/SkillStackView.js
@@ -41,6 +41,8 @@ const SkillViewContainer = styled.div`
     align-items: center;
   }
   .menu-title {
+    font-size: 15px;
+    font-weight: 500;
     cursor: pointer;
     width: 100% auto;
     height: 100%;
@@ -181,7 +183,7 @@ const SkillStackView = () => {
     },
     {
       tabTitle: '기타',
-      tabCont: [{ skillId: 1, name: 'Figma' }],
+      tabCont: [],
     },
   ];
   // 클릭된 탭으로 변경

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -1,5 +1,283 @@
+import styled from 'styled-components';
+import ProfileCard from '../components/ProfileCard';
+import SkillStackView from '../components/SkillStackView';
+import InterestView from '../components/InterestView';
+import ArticleCard from '../components/ArticleCard';
+import {
+  currentUserState,
+  recruitedArticlesState,
+  likedArticlesState,
+  userProfileState,
+  skillStackViewState,
+  interestViewState,
+} from '../atom/atom';
+import { useRecoilState, useSetRecoilState, useRecoilValue } from 'recoil';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+
+const Container = styled.div`
+  min-height: calc(100vh - 62px); //전체화면-헤더 높이
+  width: fit-content;
+  color: var(--black);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .profile-card {
+    margin-top: 40px;
+  }
+
+  .skill-stack {
+    border-radius: 8px;
+    background-color: white;
+    width: 762px;
+    margin-top: 20px;
+    padding: 20px 30px;
+  }
+
+  .interest {
+    border-radius: 8px;
+    background-color: white;
+    width: 762px;
+    margin-top: 20px;
+    padding: 20px 30px;
+  }
+
+  .article-area {
+    width: calc(100vw - 340px);
+    min-width: 762px;
+  }
+
+  .article-menu {
+    padding: 60px 0 0 0;
+    display: flex;
+  }
+
+  .menu:first-child {
+    border-right: 1px solid var(--purple-medium);
+    margin-right: 20px;
+  }
+
+  .menu {
+    background-color: transparent;
+    padding: 0 20px 0 0;
+    text-align: start;
+    font-size: 18px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .active-menu {
+    color: var(--purple);
+
+    .menu-content-count {
+      color: var(--black);
+    }
+  }
+
+  .menu-content-count {
+    margin-top: 5px;
+    font-size: 15px;
+    font-weight: normal;
+  }
+
+  .article-list {
+    /* min-height: 100px; */
+    margin-bottom: 100px;
+  }
+
+  .article-list > * {
+    margin: 30px 30px 0 0;
+  }
+`;
+
 const MyPage = () => {
-  return <div>ddd</div>;
+  const [activeMenu, setActiveMenu] = useState(0);
+
+  const currentUser = useRecoilValue(currentUserState); //로그인 후, 응답으로 받아 오는 멤버아이디
+  const [profileData, setProfileData] = useRecoilState(userProfileState); //프로필카드
+  const [skillStackView, setSkillStackView] =
+    useRecoilState(skillStackViewState); //기술스택
+  const setInterestView = useSetRecoilState(interestViewState); //관심분야
+  const [recruitedArticles, setRecruitedArticles] = useRecoilState(
+    recruitedArticlesState,
+  ); //모집 프로젝트
+  const [likedArticles, setLikedArticles] = useRecoilState(likedArticlesState); //좋아요 프로젝트
+
+  useEffect(() => {
+    axios.get(`/members/${currentUser.memberId}`).then((res) => {
+      // 프로필카드 상태 set
+      const userProfile = {
+        memberId: res.data.data.memberId,
+        email: res.data.data.email,
+        name: res.data.data.name,
+        description: res.data.data.description,
+        level: res.data.data.level,
+        github: res.data.data.github,
+      };
+      setProfileData(userProfile);
+
+      // 기술스택 상태 set
+      for (let el of res.data.data.skills) {
+        if (el.skillSort === '프론트엔드') {
+          setSkillStackView([
+            {
+              tabTitle: '프론트엔드',
+              tabCont: [
+                ...skillStackView[0].tabCont,
+                {
+                  skillId: skillStackView[0].tabCont.length + 1,
+                  name: el.name,
+                },
+              ],
+            },
+            {
+              tabTitle: '백엔드',
+              tabCont: [...skillStackView[1].tabCont],
+            },
+            {
+              tabTitle: '기타',
+              tabCont: [...skillStackView[2].tabCont],
+            },
+          ]);
+        }
+        if (el.skillSort === '백엔드') {
+          setSkillStackView([
+            {
+              tabTitle: '프론트엔드',
+              tabCont: [...skillStackView[0].tabCont],
+            },
+            {
+              tabTitle: '백엔드',
+              tabCont: [
+                ...skillStackView[1].tabCont,
+                {
+                  skillId: skillStackView[1].tabCont.length + 1,
+                  name: el.name,
+                },
+              ],
+            },
+            {
+              tabTitle: '기타',
+              tabCont: [...skillStackView[2].tabCont],
+            },
+          ]);
+        }
+        if (el.skillSort !== '백엔드' && el.skillSort !== '프론트엔드') {
+          setSkillStackView([
+            {
+              tabTitle: '프론트엔드',
+              tabCont: [...skillStackView[0].tabCont],
+            },
+            {
+              tabTitle: '백엔드',
+              tabCont: [...skillStackView[1].tabCont],
+            },
+            {
+              tabTitle: '기타',
+              tabCont: [
+                ...skillStackView[2].tabCont,
+                {
+                  skillId: skillStackView[2].tabCont.length + 1,
+                  name: el.name,
+                },
+              ],
+            },
+          ]);
+        }
+      }
+
+      //관심분야 상태 set
+      setInterestView(res.data.data.interests);
+
+      //모집프로젝트 목록 상태 set
+      setRecruitedArticles(res.data.data.articles);
+
+      //좋아요프로젝트 목록 상태 set
+      setLikedArticles(res.data.data.heartArticles);
+    });
+  }, []);
+
+  const tabContArr = [
+    { tabTitle: '모집한 프로젝트', tabCont: recruitedArticles },
+    { tabTitle: '좋아요한 프로젝트', tabCont: likedArticles },
+  ];
+
+  const onClickMenu = (idx) => {
+    setActiveMenu(idx);
+  };
+
+  const onlinkToEdit = () => {
+    location.href = `/mypage/edit/${profileData.memberId}`;
+    // location.href = `/mypage/edit/${profileData.memberId}`;
+  };
+
+  const onMemberDelete = () => {
+    axios.delete(`/members/${currentUser.memberId}`);
+    location.href = `/`;
+  };
+
+  return (
+    <Container>
+      <div className="profile-card">
+        <ProfileCard
+          onEditProfile={() => {
+            onlinkToEdit();
+          }}
+          onDeleteProfile={() => {
+            onMemberDelete();
+          }}
+        />
+      </div>
+      <div className="skill-stack">
+        <SkillStackView />
+      </div>
+      <div className="interest">
+        <InterestView />
+      </div>
+      <div className="article-area">
+        <ul className="article-menu">
+          {tabContArr.map((menu, idx) => {
+            return (
+              // 메뉴 버튼
+              <div
+                role="presentation"
+                key={idx}
+                className={activeMenu === idx ? 'menu active-menu' : 'menu'}
+                onClick={() => onClickMenu(idx)}
+              >
+                {menu.tabTitle}
+                <div className="menu-content-count">{`총 ${menu.tabCont.length}개 프로젝트`}</div>
+              </div>
+            );
+          })}
+        </ul>
+
+        <ul className="article-list">
+          {tabContArr[activeMenu].tabCont.map((article, idx) => {
+            return (
+              <ArticleCard
+                key={idx}
+                articleId={article.articleId}
+                isCompleted={article.isCompleted}
+                title={article.title}
+                startDay={article.startDay}
+                endDay={article.endDay}
+                frontend={article.frontend}
+                backend={article.backend}
+                hashtags={article.hashtags}
+                skills={article.skills}
+                memberName={article.memberName}
+                heartCount={article.heartCount}
+                views={article.views}
+              />
+            );
+          })}
+        </ul>
+      </div>
+    </Container>
+  );
 };
 
 export default MyPage;

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -210,12 +210,21 @@ const MyPage = () => {
 
   const onlinkToEdit = () => {
     location.href = `/mypage/edit/${profileData.memberId}`;
-    // location.href = `/mypage/edit/${profileData.memberId}`;
+    // location.href = `/mypage/edit/${currentUser.memberId}`;
   };
 
   const onMemberDelete = () => {
-    axios.delete(`/members/${currentUser.memberId}`);
-    location.href = `/`;
+    let isGo = window.confirm('탈퇴하시겠습니까?');
+
+    if (isGo) {
+      window.alert('탈퇴되었습니다');
+      // axios.delete(`/members/${currentUser.memberId}`); // 서버에 탈퇴 요청
+      // 로그인 여부 상태 초기화 코드 자리
+      // 로그인된 유저의 정보 (유저 아이디) 상태 초기화 코드 자리
+      window.location = '/';
+    } else {
+      console.log('stay');
+    }
   };
 
   return (


### PR DESCRIPTION
#61 

- **pakage.json**
  - CORS 에러 해결을 위한 proxy 설정 추가

- **App.js**
  - 스크롤 없는 꽉찬 화면을 위해 CSS -> 프론트엔드 공통 수정 사항 반영

- **atom.js**
  - 사용자 관심 분야 목록, 기술 스택 목록을 담은 상태의 테스트 데이터를 삭제하고 초기값으로 재설정
  - 사용자가 모집한 프로젝트 목록, 사용자가 좋아요한 프로젝트 목록을 담은 상태 추가
  
- **ArticleCard.js**
  - 게시글 카드 클릭했을 때, 해당 게시글 상세 페이지로 이동하도록 Link 연결 주소를 수정
  
- **Header.js**
  - 헤더를 상단에 고정시키는 CSS 코드 추가 -> 프론트엔드 공통 수정 사항 반영
  - 각 탭의 글자들이 nowrap 되도록 CSS 코드 추가 -> 프론트엔드 공통 수정 사항 반영
  
- **InterestView.js**
  - 삭제되지 못한 빨간 border가 있어 삭제
  
- ### **MyPage.js**
  - useEffect로 처음 렌더링 될 때, 
     axios를 사용해 마이페이지에서 필요한 정보를 받아와 setState로 상태값 설정해주었습니다!
  - 수정하기 버튼을 클릭했을 때, 해당 유저의 memberId를 활용해 마이페이지 수정페이지로 이동하게 했습니다.
  - 탈퇴하기 버튼을 클릭했을 때, 안내창을 띄워 한 번더 탈퇴여부를 묻고 응답에 따라 (해당 유저의 memberId를 활용해) 탈퇴요청을 서버에 보내거나 현재페이지에 남아있을 수 있도록 코드를 작성해보았습니다.
  탈퇴요청을 서버에 보냈다면 탈퇴되어 마이페이지가 없어졌을 것이기 때문에 메인페이지로 이동하도록 코드를 작성해보았습니다.
  **현재는 탈퇴하기 코드와 탈퇴후 처리해줄 로그인상태나 유저정보초기화를 어떻게 해야할 지 몰라서 우선 작성해두고 주석처리해두었습니다!**

![PR 마이페이지 구현 영상](https://user-images.githubusercontent.com/107869548/203311053-b64c3893-4294-4395-b168-59ff63defb08.gif)

ㄴ 구현 영상 속 게시글 카드를 클릭하거나 버튼 클릭했을 때 엔드포인트가 달라지고 있는데,
 잘 되고 있는 건지 한 번 확인 부탁드립니다!

### 추가 사항
일단 기능 구현은 다 되었기 떄문에 PR을 올립니다!
아직 반응형은 구현되지 않은 상태입니다.
다들 프로필카드나 게시글 카드처럼 컴포넌트 크기는 괜찮은 것 같으신가요??
또, 수정할 사항이 있다면 코멘트로 남겨주세요!
  