### PR TITLE
Refactor: 기술스택 선택란/ 보기란 리팩토링

### DIFF
--- a/client/src/atom/atom.js
+++ b/client/src/atom/atom.js
@@ -57,7 +57,7 @@ export const interestViewState = atom({
 
 // 사용자의 기술 스택 목록 상태
 export const skillStackViewState = atom({
-  key: 'skillViewState',
+  key: 'skillStackViewState',
   default: [
     {
       tabTitle: '프론트엔드',
@@ -84,7 +84,7 @@ export const userProfileState = atom({
 export const currentUserState = atom({
   key: 'isLoginState',
   default: {
-    memberId: 1,
+    memberId: 2,
   },
 });
 

--- a/client/src/components/SkillStackSelect.js
+++ b/client/src/components/SkillStackSelect.js
@@ -22,7 +22,18 @@ import {
   SiPhp,
   SiGraphql,
   SiFirebase,
+  SiFlutter,
+  SiSwift,
+  SiUnity,
+  SiAmazonaws,
+  SiKubernetes,
+  SiDocker,
+  SiGit,
+  SiFigma,
+  SiJest,
+  SiCplusplus,
 } from 'react-icons/si';
+import { GiZeppelin } from 'react-icons/gi';
 
 const InterestSelectWrapper = styled.div`
   width: 100%;
@@ -71,32 +82,6 @@ const InterestSelectWrapper = styled.div`
   .active-title {
     color: var(--purple);
     border-bottom: 3px solid var(--purple);
-  }
-`;
-
-const Input = styled.input`
-  width: 100%;
-  height: 30px;
-  padding: 8px 8px 10px;
-  margin: 10px 10px;
-  border-radius: 8px;
-  border: none;
-  color: var(--black);
-  outline: none;
-  border: 1px solid var(--purple-medium);
-  transition: 300ms ease-in-out;
-  white-space: nowrap;
-  line-height: 0;
-
-  &:hover,
-  &:focus,
-  &:active {
-    border-color: var(--purple);
-  }
-
-  &:focus,
-  &:active {
-    box-shadow: 0px 0px 0px 4px var(--purple-medium);
   }
 `;
 
@@ -240,19 +225,69 @@ const tabContArr = [
   },
   {
     tabTitle: '기타',
-    tabCont: [],
+    tabCont: [
+      {
+        name: 'Flutter',
+        img: <SiFlutter className="interest-tag-img" color="#02569B" />,
+      },
+      {
+        name: 'Switft',
+        img: <SiSwift className="interest-tag-img" color="#F05138" />,
+      },
+      {
+        name: 'ReactNative',
+        img: <SiReact className="interest-tag-img" color="#61DAFB" />,
+      },
+      {
+        name: 'Unity',
+        img: <SiUnity className="interest-tag-img" color="#000000" />,
+      },
+      {
+        name: 'AWS',
+        img: <SiAmazonaws className="interest-tag-img" color="#232F3E" />,
+      },
+      {
+        name: 'Kubernetes',
+        img: <SiKubernetes className="interest-tag-img" color="#326CE5" />,
+      },
+      {
+        name: 'Docker',
+        img: <SiDocker className="interest-tag-img" color="#2496ED" />,
+      },
+      {
+        name: 'Git',
+        img: <SiGit className="interest-tag-img" color="#F05032" />,
+      },
+      {
+        name: 'Figma',
+        img: <SiFigma className="interest-tag-img" color="#5B0BB5" />,
+      },
+      {
+        name: 'Zeplin',
+        img: <GiZeppelin className="interest-tag-img" color="#FF9900" />,
+      },
+      {
+        name: 'Jest',
+        img: <SiJest className="interest-tag-img" color="#C21325" />,
+      },
+      {
+        name: 'C',
+        img: <SiCplusplus className="interest-tag-img" color="#00599C" />,
+      },
+    ],
   },
 ];
 
-const Tag = ({ tag, onClick, isSelected, onDelete, icon }) => {
+const Tag = ({ tag, onClick, isSelected, onDelete, icon, icon2 }) => {
   return (
     <li>
       <TagBtn
-        onClick={() => (isSelected ? onDelete(tag) : onClick(tag))}
+        onClick={() => (isSelected ? onDelete(tag) : onClick(tag, icon))}
         className={isSelected ? 'selected-tag' : ''}
       >
         {icon}
         {tag}
+        {icon2}
       </TagBtn>
     </li>
   );
@@ -263,6 +298,7 @@ const SkillStackSelect = () => {
   const [selectedSkillstacks, setSelectedSkillstacks] = useRecoilState(
     selectedSkillstacksState,
   );
+  let selectedSkillstacksNameArr = [];
 
   const onTabClick = (index) => {
     setActiveIdx(index); // 클릭한 탭으로 활성화 탭 변경
@@ -270,36 +306,23 @@ const SkillStackSelect = () => {
 
   const onDeleteClick = (selectedTag) => {
     setSelectedSkillstacks([
-      ...selectedSkillstacks.filter((tag) => tag !== selectedTag),
+      ...selectedSkillstacks.filter((tag) => tag.name !== selectedTag),
     ]);
   };
 
-  const onTagClick = (selectedTag) => {
+  const onTagClick = (selectedTag, icon) => {
     if (!selectedSkillstacks.includes(selectedTag)) {
-      setSelectedSkillstacks([...selectedSkillstacks, selectedTag]);
+      let selected = {
+        name: selectedTag,
+        img: icon,
+      };
+      setSelectedSkillstacks([...selectedSkillstacks, selected]);
     }
   };
 
-  const onInputKeyUp = (e) => {
-    const duplicateCheck = selectedSkillstacks.filter(
-      (el) => el === e.target.value,
-    );
-    // 중복 확인 위한 arr(중복X: null, 중복: 값O)
-
-    if (
-      e.key === 'Enter' &&
-      duplicateCheck.length === 0 &&
-      e.target.value.length > 0
-    ) {
-      let newSkillName = e.target.value;
-      setSelectedSkillstacks([...selectedSkillstacks, newSkillName]); // 태그가 추가된 arr를 선택태그리스트 값으로 재설정
-      e.target.value = '';
-    } else if (
-      duplicateCheck.length !== 0 &&
-      e.key === 'Enter' // 중복 태그 시
-    ) {
-      e.target.value = '';
-    }
+  const selectedSkillstacksName = (selectedSkillstacks, selectedTag) => {
+    selectedSkillstacksNameArr = selectedSkillstacks.map((el) => el.name);
+    return selectedSkillstacksNameArr.includes(selectedTag);
   };
 
   return (
@@ -307,9 +330,10 @@ const SkillStackSelect = () => {
       <TagList className="selected-tag-list">
         {selectedSkillstacks.map((item, idx) => (
           <Tag
-            icon={<RiDeleteBack2Fill className="delete-btn" />}
+            icon={item.img}
+            icon2={<RiDeleteBack2Fill className="delete-btn" />}
             key={idx}
-            tag={item}
+            tag={item.name}
             onDelete={onDeleteClick}
             isSelected={true}
           ></Tag>
@@ -331,24 +355,16 @@ const SkillStackSelect = () => {
         })}
       </ul>
       <TagList className="tag-list">
-        {activeIdx === 2 ? (
-          <Input
-            className="skill-tag-input"
-            placeholder="기술 태그를 직접 입력해주세요."
-            onKeyUp={onInputKeyUp}
-          ></Input>
-        ) : (
-          tabContArr[activeIdx].tabCont.map((item, idx) => (
-            <Tag
-              icon={item.img}
-              key={idx}
-              tag={item.name}
-              onClick={onTagClick}
-              onDelete={onDeleteClick}
-              isSelected={selectedSkillstacks.includes(item.name)}
-            />
-          ))
-        )}
+        {tabContArr[activeIdx].tabCont.map((item, idx) => (
+          <Tag
+            icon={item.img}
+            key={idx}
+            tag={item.name}
+            onClick={onTagClick}
+            onDelete={onDeleteClick}
+            isSelected={selectedSkillstacksName(selectedSkillstacks, item.name)}
+          />
+        ))}
       </TagList>
     </InterestSelectWrapper>
   );

--- a/client/src/components/SkillStackSelect.js
+++ b/client/src/components/SkillStackSelect.js
@@ -231,7 +231,7 @@ const tabContArr = [
         img: <SiFlutter className="interest-tag-img" color="#02569B" />,
       },
       {
-        name: 'Switft',
+        name: 'Swift',
         img: <SiSwift className="interest-tag-img" color="#F05138" />,
       },
       {
@@ -278,7 +278,7 @@ const tabContArr = [
   },
 ];
 
-const Tag = ({ tag, onClick, isSelected, onDelete, icon, icon2 }) => {
+const Tag = ({ tag, onClick, isSelected, onDelete, icon, iconDelete }) => {
   return (
     <li>
       <TagBtn
@@ -287,7 +287,7 @@ const Tag = ({ tag, onClick, isSelected, onDelete, icon, icon2 }) => {
       >
         {icon}
         {tag}
-        {icon2}
+        {iconDelete}
       </TagBtn>
     </li>
   );
@@ -298,7 +298,6 @@ const SkillStackSelect = () => {
   const [selectedSkillstacks, setSelectedSkillstacks] = useRecoilState(
     selectedSkillstacksState,
   );
-  let selectedSkillstacksNameArr = [];
 
   const onTabClick = (index) => {
     setActiveIdx(index); // 클릭한 탭으로 활성화 탭 변경
@@ -320,8 +319,8 @@ const SkillStackSelect = () => {
     }
   };
 
-  const selectedSkillstacksName = (selectedSkillstacks, selectedTag) => {
-    selectedSkillstacksNameArr = selectedSkillstacks.map((el) => el.name);
+  const onIsSelected = (selectedSkillstacks, selectedTag) => {
+    let selectedSkillstacksNameArr = selectedSkillstacks.map((el) => el.name);
     return selectedSkillstacksNameArr.includes(selectedTag);
   };
 
@@ -331,7 +330,7 @@ const SkillStackSelect = () => {
         {selectedSkillstacks.map((item, idx) => (
           <Tag
             icon={item.img}
-            icon2={<RiDeleteBack2Fill className="delete-btn" />}
+            iconDelete={<RiDeleteBack2Fill className="delete-btn" />}
             key={idx}
             tag={item.name}
             onDelete={onDeleteClick}
@@ -362,7 +361,7 @@ const SkillStackSelect = () => {
             tag={item.name}
             onClick={onTagClick}
             onDelete={onDeleteClick}
-            isSelected={selectedSkillstacksName(selectedSkillstacks, item.name)}
+            isSelected={onIsSelected(selectedSkillstacks, item.name)}
           />
         ))}
       </TagList>

--- a/client/src/components/SkillStackView.js
+++ b/client/src/components/SkillStackView.js
@@ -21,7 +21,18 @@ import {
   SiPhp,
   SiGraphql,
   SiFirebase,
+  SiFlutter,
+  SiSwift,
+  SiUnity,
+  SiAmazonaws,
+  SiKubernetes,
+  SiDocker,
+  SiGit,
+  SiFigma,
+  SiJest,
+  SiCplusplus,
 } from 'react-icons/si';
+import { GiZeppelin } from 'react-icons/gi';
 import { activeMenuState, skillStackViewState } from '../atom/atom';
 
 const SkillViewContainer = styled.div`
@@ -183,7 +194,56 @@ const SkillStackView = () => {
     },
     {
       tabTitle: '기타',
-      tabCont: [],
+      tabCont: [
+        {
+          name: 'Flutter',
+          img: <SiFlutter className="skill-tag-img" color="#02569B" />,
+        },
+        {
+          name: 'Switft',
+          img: <SiSwift className="skill-tag-img" color="#F05138" />,
+        },
+        {
+          name: 'ReactNative',
+          img: <SiReact className="skill-tag-img" color="#61DAFB" />,
+        },
+        {
+          name: 'Unity',
+          img: <SiUnity className="skill-tag-img" color="#000000" />,
+        },
+        {
+          name: 'AWS',
+          img: <SiAmazonaws className="skill-tag-img" color="#232F3E" />,
+        },
+        {
+          name: 'Kubernetes',
+          img: <SiKubernetes className="skill-tag-img" color="#326CE5" />,
+        },
+        {
+          name: 'Docker',
+          img: <SiDocker className="skill-tag-img" color="#2496ED" />,
+        },
+        {
+          name: 'Git',
+          img: <SiGit className="skill-tag-img" color="#F05032" />,
+        },
+        {
+          name: 'Figma',
+          img: <SiFigma className="skill-tag-img" color="#5B0BB5" />,
+        },
+        {
+          name: 'Zeplin',
+          img: <GiZeppelin className="skill-tag-img" color="#FF9900" />,
+        },
+        {
+          name: 'Jest',
+          img: <SiJest className="skill-tag-img" color="#C21325" />,
+        },
+        {
+          name: 'C',
+          img: <SiCplusplus className="skill-tag-img" color="#00599C" />,
+        },
+      ],
     },
   ];
   // 클릭된 탭으로 변경


### PR DESCRIPTION
#67 

- atom.js
  - 사용자 기술스택 상태의 키값이 똑같이 설정되어있지 않는 걸 보고 수정해놨습니다..!

- ### SkillStackSelect.js
  - 기타탭에 선택지를 추가하기 위해 태그 이름과 이미지를 
  FE, BE 탭 형식과 같도록 데이터를 넣어두었습니다.
  - 삭제 아이콘 뿐만아니라 해당 기술스택의 로고아이콘도 같이 들어가야하기 때문에 
  Tag 컴포넌트의 매개변수로 icon2를 추가해주었습니다.
  (icon은 기술스택로고, icon2는 삭제버튼 아이콘)
  - 태그를 onClick했을 때, 기존의 기술스택 이름만 필요한 것이 아니라, 해당 아이콘도 함께 저장해야하기 때문에 onClick의 매개변수에 icon을 추가해주었습니다.
  또한, icon과 기술스택 이름을 함께 묶어 저장해야하기 때문에 객체형태로 상태에 저장되도록 수정했습니다.
  후에 정보를 보낼 때는 아래와 같이 상태를 변형해 담아주어야 할 것 같습니다.
  
```javascript
새로운 변수 이름 = 배열 안에 이름, 이미지태그를 객체로 담은 상태.map((el) => 
  return {skillName : el.name})

{
  "email" : "hgd@gmail.com",
  "name" : "홍길동",
  "password" : "hgd1234!",
  "passwordCheck" : "hgd1234!",
  "memberInterests" :  : [ {
    "interestName" : "교육"
  } ],
  "memberSkills" : 새로운 변수 이름
}
```
![PR 기술스택선택란 리팩토링](https://user-images.githubusercontent.com/107869548/203552779-eb602b46-40d4-42a7-a608-015afc68aea1.gif)
ㄴ 기술스택선택란 기타탭 부분 현재 상태

- ### SkillStackView.js
  - 기타탭에 선택지를 추가하기 위해 태그 이름과 이미지를 
  FE, BE 탭 형식과 같도록 데이터를 넣어두었습니다.
  
![PR 기술스택보기란 리팩토링](https://user-images.githubusercontent.com/107869548/203553025-0ff6af76-55fb-4c81-9b9c-ba30452dfb6d.gif)
ㄴ 기술스택보기란 기타탭 부분 현재 상태