### PR TITLE
Feat: 메인 페이지 구현

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -49,5 +49,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.10",
     "eslint-plugin-react-hooks": "^4.6.0"
-  }
+  },
+  "proxy": "http://ec2-15-165-2-129.ap-northeast-2.compute.amazonaws.com:8080"
 }

--- a/client/src/atom/atom.js
+++ b/client/src/atom/atom.js
@@ -128,3 +128,9 @@ export const inputHashTagsState = atom({
   key: 'inputHashTagsState',
   default: [],
 });
+
+// 게시글 목록
+export const articlesListState = atom({
+  key: 'articlesListState',
+  default: [],
+});

--- a/client/src/components/ArticlesGrid.js
+++ b/client/src/components/ArticlesGrid.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const ArticlesGrid = styled.div`
+  display: grid;
+  grid-template-rows: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(323px, 1fr));
+  gap: 30px;
+`;
+
+export default ArticlesGrid;

--- a/client/src/components/CloseButton.js
+++ b/client/src/components/CloseButton.js
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+import { GrClose } from 'react-icons/gr';
+
+const Button = styled.button`
+  width: 30px;
+  height: 30px;
+  padding-top: 2px;
+  border-radius: 15px;
+  border: none;
+  background-color: transparent;
+  transition: 300ms ease-in-out;
+
+  svg path {
+    stroke: var(--purple);
+  }
+
+  &:hover {
+    background-color: var(--purple-medium);
+  }
+
+  &:active {
+    background-color: var(--purple);
+    svg path {
+      stroke: #fff;
+    }
+  }
+`;
+
+const CloseButton = ({ onClick, className }) => {
+  return (
+    <Button className={className} onClick={onClick}>
+      <GrClose />
+    </Button>
+  );
+};
+
+export default CloseButton;

--- a/client/src/components/DefaultButton.js
+++ b/client/src/components/DefaultButton.js
@@ -9,7 +9,7 @@ const Button = styled.button`
   color: var(--purple);
   border: 1px solid var(--purple);
   font-size: 18px;
-  font-weight: 800;
+  font-weight: 700;
   transition: 300ms ease-in-out;
 
   &:hover {
@@ -23,8 +23,12 @@ const Button = styled.button`
   }
 `;
 
-const DefaultButton = ({ text, onClick }) => {
-  return <Button onClick={onClick}>{text}</Button>;
+const DefaultButton = ({ text, onClick, className }) => {
+  return (
+    <Button onClick={onClick} className={className || ''}>
+      {text}
+    </Button>
+  );
 };
 
 export default DefaultButton;

--- a/client/src/components/ExtendedButton.js
+++ b/client/src/components/ExtendedButton.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+import DefaultButton from './DefaultButton';
+
+const ExtendedButton = styled(DefaultButton)`
+  width: calc(100% + 2px);
+  margin: -1px;
+  border-radius: 0 0 8px 8px;
+`;
+
+export default ExtendedButton;

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -11,6 +11,12 @@ const HeaderContainer = styled.header`
   justify-content: space-between;
   position: fixed;
 
+  z-index: 2;
+  position: sticky;
+  top: 0;
+  right: 0;
+  left: 0;
+
   .header-container {
     width: 100%;
     padding: 13px;

--- a/client/src/components/ScrollTopButton.js
+++ b/client/src/components/ScrollTopButton.js
@@ -3,9 +3,26 @@ import { IoIosArrowUp } from 'react-icons/io';
 import styled from 'styled-components';
 
 const Button = styled.button`
+  position: fixed;
+  bottom: 100px;
+  right: 100px;
+  width: 57px;
+  height: 57px;
   background-color: #ffffff;
   border-radius: 50%;
   border: none;
+  animation: fadein 1s alternate;
+
+  @keyframes fadein {
+    from {
+      opacity: 0;
+      transform: translate(0, 100px);
+    }
+    to {
+      opacity: 1;
+      transform: translate(0, 0);
+    }
+  }
 `;
 
 const ScrollTopButton = () => {

--- a/client/src/components/SkillFilterSelector.js
+++ b/client/src/components/SkillFilterSelector.js
@@ -1,0 +1,121 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+import { useRecoilState } from 'recoil';
+import { selectedSkillstacksState } from '../atom/atom';
+import SkillStackSelect from './SkillStackSelect';
+import ExtendedButton from './ExtendedButton';
+import CloseButton from './CloseButton';
+import { TbFilter } from 'react-icons/tb';
+
+const FilterSelectorWrapper = styled.div`
+  .filter-modal-toggle {
+    height: 36px;
+    margin-left: 10px;
+    padding-left: 4px;
+
+    background-color: var(--purple-light);
+    border: solid 2px var(--purple);
+    border-radius: 20px;
+    padding: 0 0.9em;
+
+    font-weight: 700;
+    font-size: 13px;
+    color: var(--purple);
+
+    transition: 300ms ease-in-out;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &.opened {
+      background-color: var(--purple-medium);
+    }
+
+    svg {
+      stroke: var(--purple);
+      margin-right: -3px;
+    }
+  }
+
+  .filter-selector-modal {
+    width: 695px;
+    max-width: 100%;
+    margin-top: 10px;
+    position: absolute;
+    right: 0;
+    z-index: 1;
+    background-color: #fff;
+    border: 1px solid var(--purple);
+    border-radius: 8px;
+
+    .filter-contents {
+      margin: 24px;
+
+      p {
+        margin-bottom: 22px;
+        text-align: left;
+        font-weight: 700;
+        font-size: 15px;
+        color: var(--black);
+      }
+    }
+
+    .close-btn {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+    }
+  }
+`;
+
+const SkillFilterSelector = ({ setSkillFilter, setModalDisplay, isOpened }) => {
+  const [selectedSkillStacks, setSelectedSkillStacks] = useRecoilState(
+    selectedSkillstacksState,
+  );
+  const [isFiltered, setIsFiltered] = useState(false);
+
+  const onToggle = () => {
+    setModalDisplay();
+    if (!isFiltered) setSelectedSkillStacks([]);
+  };
+
+  const onApply = () => {
+    setSkillFilter(
+      selectedSkillStacks.map((el) => {
+        return el.name;
+      }),
+    );
+    setIsFiltered(true);
+  };
+
+  return (
+    <FilterSelectorWrapper>
+      <button
+        className={
+          isOpened ? 'filter-modal-toggle opened' : 'filter-modal-toggle'
+        }
+        onClick={() => onToggle()}
+      >
+        필터링
+        <TbFilter size={23} />
+      </button>
+      {isOpened && (
+        <div className="filter-selector-modal">
+          <div className="filter-contents">
+            <p>기술 스택으로 필터를 설정해보세요!</p>
+            <SkillStackSelect />
+          </div>
+          <ExtendedButton
+            text="적용하기"
+            onClick={() => onApply()}
+            className="apply-btn"
+          />
+          <CloseButton className="close-btn" onClick={() => onToggle()} />
+        </div>
+      )}
+    </FilterSelectorWrapper>
+  );
+};
+
+export default SkillFilterSelector;

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -1,142 +1,337 @@
+/* eslint-disable no-unused-vars */
 import ArticleCard from '../components/ArticleCard';
+import styled from 'styled-components';
+import { GrClose } from 'react-icons/gr';
+import { TbFilter } from 'react-icons/tb';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { articlesListState, selectedSkillstacksState } from '../atom/atom';
+import { useState, useEffect, useCallback } from 'react';
+import axios from 'axios';
+import SwitchToggle from '../components/SwitchToggle';
+import DefaultButton from '../components/DefaultButton';
+import SkillStackSelect from '../components/SkillStackSelect';
 
-const dummy = [
-  {
-    articleId: 1,
-    title:
-      '헬스케어 식단 관련 프로젝트를 같이 진행할 백엔드 개발자님을 구합니다',
-    body: '본문1',
-    views: 23,
-    isCompleted: false,
-    startDay: '20221109',
-    endDay: '20221210',
-    backend: 3,
-    frontend: 3,
-    memberId: 1,
-    memberName: '홍길동',
-    createdAt: '2022-11-15T17:21:00.0288716',
-    modifiedAt: '2022-11-15T17:21:00.0288716',
-    heartCount: 10,
-    answerCount: 1,
-    hashtags: [
-      {
-        hashtagId: 1,
-        name: '해쉬태그1',
-      },
-    ],
-    interests: [
-      {
-        interestId: 1,
-        name: '교육',
-      },
-    ],
-    skills: [
-      {
-        skillId: 1,
-        name: 'JavaScript',
-      },
-      {
-        skillId: 3,
-        name: 'React',
-      },
-    ],
-  },
-  {
-    articleId: 2,
-    title: '제목2',
-    body: '본문2',
-    views: 0,
-    isCompleted: false,
-    startDay: '20221110',
-    endDay: '20221211',
-    backend: 2,
-    frontend: 2,
-    memberId: 2,
-    memberName: '고길동',
-    createdAt: '2022-11-15T17:21:00.0288716',
-    modifiedAt: '2022-11-15T17:21:00.0288716',
-    heartCount: 0,
-    answerCount: 1,
-    hashtags: [
-      {
-        hashtagId: 1,
-        name: '해쉬태그1',
-      },
-    ],
-    interests: [
-      {
-        interestId: 1,
-        name: '미디어',
-      },
-    ],
-    skills: [
-      {
-        skillId: 1,
-        name: 'spring',
-      },
-    ],
-  },
-  {
-    articleId: 3,
-    title: '제목3',
-    body: '본문3',
-    views: 0,
-    isCompleted: true,
-    startDay: '20221111',
-    endDay: '20221212',
-    backend: 3,
-    frontend: 4,
-    memberId: 3,
-    memberName: '김길동',
-    createdAt: '2022-11-15T17:21:00.0288716',
-    modifiedAt: '2022-11-15T17:21:00.0288716',
-    heartCount: 0,
-    answerCount: 1,
-    hashtags: [
-      {
-        hashtagId: 1,
-        name: '해쉬태그1',
-      },
-    ],
-    interests: [
-      {
-        interestId: 1,
-        name: '제조',
-      },
-    ],
-    skills: [
-      {
-        skillId: 1,
-        name: 'Nodejs',
-      },
-    ],
-  },
-];
+const Container = styled.div`
+  min-height: calc(100vh - 62px);
+  width: 100%;
+  margin: 0 170px;
+
+  h1 {
+    padding: 67px 0 77px;
+    border-bottom: 1px solid var(--purple-medium);
+  }
+
+  .view-options {
+    text-align: right;
+    position: relative;
+    margin: 20px 0 32px;
+
+    .filter-options {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .sort-options {
+      margin: 30px 0 -5px auto;
+
+      button {
+        font-size: 15px;
+        font-weight: 700;
+        color: var(--grey-dark);
+        margin: 5px;
+        cursor: pointer;
+        background-color: transparent;
+        border: none;
+
+        &.active-option {
+          color: var(--purple);
+        }
+
+        &:not(:last-child)::after {
+          content: '|';
+          margin-left: 11px;
+          color: var(--purple-medium);
+        }
+      }
+    }
+  }
+`;
+
+const ArticlesGrid = styled.div`
+  display: grid;
+  grid-template-rows: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(323px, 1fr));
+  gap: 30px;
+`;
+
+const FilterSelectorWrapper = styled.div`
+  .filter-modal-toggle {
+    width: 100px;
+    height: 36px;
+    margin-left: 10px;
+    padding-left: 4px;
+
+    background-color: var(--purple-light);
+    border: solid 1px var(--purple);
+    border-radius: 20px;
+
+    font-weight: 400;
+    font-size: 15px;
+    color: var(--purple);
+
+    transition: 300ms ease-in-out;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &.opened {
+      background-color: var(--purple-medium);
+    }
+  }
+
+  .filter-selector-modal {
+    width: 695px;
+    max-width: 100%;
+    margin-top: 10px;
+    position: absolute;
+    right: 0;
+    z-index: 1;
+    background-color: #fff;
+    border: 1px solid var(--purple);
+    border-radius: 8px;
+
+    .filter-contents {
+      margin: 24px;
+
+      p {
+        margin-bottom: 22px;
+        text-align: left;
+        font-weight: 700;
+        font-size: 15px;
+        color: var(--black);
+      }
+    }
+
+    .close-btn {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+    }
+  }
+`;
+
+const CloseBtn = styled.button`
+  width: 30px;
+  height: 30px;
+  padding-top: 2px;
+  border-radius: 15px;
+  border: none;
+  background-color: transparent;
+  transition: 300ms ease-in-out;
+
+  svg path {
+    stroke: var(--purple);
+  }
+
+  &:hover {
+    background-color: var(--purple-medium);
+  }
+
+  &:active {
+    background-color: var(--purple);
+    svg path {
+      stroke: #fff;
+    }
+  }
+`;
+
+const CloseButton = ({ onClick, className }) => {
+  return (
+    <CloseBtn className={className} onClick={onClick}>
+      <GrClose />
+    </CloseBtn>
+  );
+};
+
+const LongButton = styled(DefaultButton)`
+  width: calc(100% + 2px);
+  margin: -1px;
+  border-radius: 0 0 8px 8px;
+`;
+
+const SkillFilterSelector = ({ onApply, onClose, isOpened }) => {
+  return (
+    <FilterSelectorWrapper>
+      <button
+        className={
+          isOpened ? 'filter-modal-toggle opened' : 'filter-modal-toggle'
+        }
+        onClick={() => onClose()}
+      >
+        필터링
+        <TbFilter />
+      </button>
+      {isOpened && (
+        <div className="filter-selector-modal">
+          <div className="filter-contents">
+            <p>기술 스택으로 필터를 설정해보세요!</p>
+            <SkillStackSelect />
+          </div>
+          <LongButton
+            text="적용하기"
+            onClick={() => onApply()}
+            className="apply-btn"
+          />
+          <CloseButton className="close-btn" onClick={onClose}>
+            <GrClose />
+          </CloseButton>
+        </div>
+      )}
+    </FilterSelectorWrapper>
+  );
+};
+
+const Loading = styled.div`
+  width: 100%;
+  height: 200px;
+  padding-top: 100px;
+  text-align: center;
+  animation: blink 2s ease-in-out infinite;
+
+  @keyframes blink {
+    50% {
+      opacity: 0;
+    }
+  }
+`;
 
 const Main = () => {
+  // 아티클 목록
+  const [articlesList, setArticlesList] = useRecoilState(articlesListState);
+  // 전체보기/모집중만 보기 선택 토글
+  const [viewAllStatus, setViewStatus] = useState(true);
+  // 스킬 스택 필터
+  const [filterModalShow, setFilterModalShow] = useState(false);
+  const selectedSkillstacks = useRecoilValue(selectedSkillstacksState);
+  const [skillfilter, setSkillFilter] = useState([]);
+  // 정렬 옵션
+  const sortOptions = {
+    최신순: '',
+    좋아요순: 'heart',
+    조회순: 'view',
+  };
+  const [sortOption, setSortOption] = useState('최신순');
+  // 데이터 로딩 상태
+  const [isFetching, setIsFetching] = useState(false);
+  // 데이터 요청 옵션
+  const [pageNumber, setPageNumber] = useState(1);
+  const [hasNextPage, setHasNextPage] = useState(true);
+  const pageSize = 3 * Math.floor((visualViewport.width - 340) / (323 + 30));
+
+  // 스크롤 감지
+  useEffect(() => {
+    const handleScroll = () => {
+      const { scrollTop, offsetHeight } = document.documentElement;
+      if (window.innerHeight + scrollTop >= offsetHeight) {
+        setIsFetching(true);
+      }
+    };
+    setIsFetching(true);
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  // 필터링/정렬 변화
+  useEffect(() => {
+    setArticlesList([]);
+    setPageNumber(1);
+    setIsFetching(true);
+    setHasNextPage(true);
+  }, [viewAllStatus, skillfilter, sortOption]);
+
+  // 데이터 요청 실행
+  useEffect(() => {
+    if (isFetching && hasNextPage) fetchArticles();
+    else if (!hasNextPage) setIsFetching(false);
+  }, [isFetching]);
+
+  // 데이터 요청 콜백
+  const fetchArticles = useCallback(async () => {
+    const skill = skillfilter.join(',');
+    const status = viewAllStatus ? '' : false;
+    const sort = sortOptions[sortOption];
+
+    const { data } = await axios.get('/articles?', {
+      params: { skill, status, page: pageNumber, sort, size: pageSize },
+    });
+
+    setArticlesList(articlesList.concat(data.data));
+    setPageNumber(data.pageInfo.page + 1);
+    setHasNextPage(data.pageInfo.totalPages !== data.pageInfo.page);
+    setIsFetching(false);
+    console.log('FETCH DATA!');
+  }, [viewAllStatus, skillfilter, sortOption, pageNumber]);
+
+  console.log('PAINT!');
   return (
-    // 사용시 dummy를 아티클 목록이 담긴 배열로 교체해주세요!:)
-    <div>
-      {dummy.map((article) => {
-        return (
-          <ArticleCard
-            key={article.articleId}
-            articleId={article.articleId}
-            isCompleted={article.isCompleted}
-            title={article.title}
-            startDay={article.startDay}
-            endDay={article.endDay}
-            frontend={article.frontend}
-            backend={article.backend}
-            hashtags={article.hashtags}
-            skills={article.skills}
-            memberName={article.memberName}
-            heartCount={article.heartCount}
-            views={article.views}
+    <Container>
+      <h1>
+        삼삼오오에서 사이드 프로젝트를 함께 할<br />
+        마음 맞는 팀원을 찾아보세요!
+      </h1>
+      <div className="view-options">
+        <div className="filter-options">
+          <SwitchToggle
+            left="전체 보기"
+            right="모집 중"
+            checked={viewAllStatus}
+            width="100px"
+            onClick={() => {
+              setViewStatus(!viewAllStatus);
+            }}
           />
-        );
-      })}
-    </div>
+          <SkillFilterSelector
+            isOpened={filterModalShow}
+            onApply={() => setSkillFilter(selectedSkillstacks)}
+            onClose={() => setFilterModalShow(!filterModalShow)}
+          />
+        </div>
+        <div className="sort-options">
+          {Object.keys(sortOptions).map((option) => (
+            <button
+              key={option}
+              className={option === sortOption ? 'active-option' : ''}
+              onClick={() => setSortOption(option)}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+      </div>
+      <ArticlesGrid>
+        {articlesList.map((article) => {
+          return (
+            <ArticleCard
+              key={article.articleId}
+              articleId={article.articleId}
+              isCompleted={article.isCompleted}
+              title={article.title}
+              startDay={article.startDay}
+              endDay={article.endDay}
+              frontend={article.frontend}
+              backend={article.backend}
+              hashtags={article.hashtags}
+              skills={article.skills}
+              memberName={article.memberName}
+              heartCount={article.heartCount}
+              views={article.views}
+            />
+          );
+        })}
+      </ArticlesGrid>
+      {isFetching && <Loading>게시글 불러오는 중...</Loading>}
+    </Container>
   );
 };
 

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -6,11 +6,11 @@ import { articlesListState, selectedSkillstacksState } from '../atom/atom';
 import { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import SwitchToggle from '../components/SwitchToggle';
-import DefaultButton from '../components/DefaultButton';
 import SkillStackSelect from '../components/SkillStackSelect';
 import ScrollTopButton from '../components/ScrollTopButton';
 import ArticlesGrid from '../components/ArticlesGrid';
 import CloseButton from '../components/CloseButton';
+import ExtendedButton from '../components/ExtendedButton';
 
 const Container = styled.div`
   min-height: calc(100vh - 62px);
@@ -119,12 +119,6 @@ const FilterSelectorWrapper = styled.div`
   }
 `;
 
-const LongButton = styled(DefaultButton)`
-  width: calc(100% + 2px);
-  margin: -1px;
-  border-radius: 0 0 8px 8px;
-`;
-
 const SkillFilterSelector = ({ setSkillFilter, setModalDisplay, isOpened }) => {
   const [selectedSkillStacks, setSelectedSkillStacks] = useRecoilState(
     selectedSkillstacksState,
@@ -162,7 +156,7 @@ const SkillFilterSelector = ({ setSkillFilter, setModalDisplay, isOpened }) => {
             <p>기술 스택으로 필터를 설정해보세요!</p>
             <SkillStackSelect />
           </div>
-          <LongButton
+          <ExtendedButton
             text="적용하기"
             onClick={() => onApply()}
             className="apply-btn"

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -1,9 +1,8 @@
-/* eslint-disable no-unused-vars */
 import ArticleCard from '../components/ArticleCard';
 import styled from 'styled-components';
 import { GrClose } from 'react-icons/gr';
 import { TbFilter } from 'react-icons/tb';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { articlesListState, selectedSkillstacksState } from '../atom/atom';
 import { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -10,6 +10,7 @@ import SwitchToggle from '../components/SwitchToggle';
 import DefaultButton from '../components/DefaultButton';
 import SkillStackSelect from '../components/SkillStackSelect';
 import ScrollTopButton from '../components/ScrollTopButton';
+import ArticlesGrid from '../components/ArticlesGrid';
 
 const Container = styled.div`
   min-height: calc(100vh - 62px);
@@ -54,13 +55,6 @@ const Container = styled.div`
       }
     }
   }
-`;
-
-const ArticlesGrid = styled.div`
-  display: grid;
-  grid-template-rows: repeat(4, 1fr);
-  grid-template-columns: repeat(auto-fill, minmax(323px, 1fr));
-  gap: 30px;
 `;
 
 const FilterSelectorWrapper = styled.div`

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -1,16 +1,13 @@
 import ArticleCard from '../components/ArticleCard';
 import styled from 'styled-components';
-import { TbFilter } from 'react-icons/tb';
 import { useRecoilState } from 'recoil';
-import { articlesListState, selectedSkillstacksState } from '../atom/atom';
+import { articlesListState } from '../atom/atom';
 import { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import SwitchToggle from '../components/SwitchToggle';
-import SkillStackSelect from '../components/SkillStackSelect';
 import ScrollTopButton from '../components/ScrollTopButton';
 import ArticlesGrid from '../components/ArticlesGrid';
-import CloseButton from '../components/CloseButton';
-import ExtendedButton from '../components/ExtendedButton';
+import SkillFilterSelector from '../components/SkillFilterSelector';
 
 const Container = styled.div`
   min-height: calc(100vh - 62px);
@@ -57,117 +54,7 @@ const Container = styled.div`
   }
 `;
 
-const FilterSelectorWrapper = styled.div`
-  .filter-modal-toggle {
-    height: 36px;
-    margin-left: 10px;
-    padding-left: 4px;
-
-    background-color: var(--purple-light);
-    border: solid 2px var(--purple);
-    border-radius: 20px;
-    padding: 0 0.9em;
-
-    font-weight: 700;
-    font-size: 13px;
-    color: var(--purple);
-
-    transition: 300ms ease-in-out;
-
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    &.opened {
-      background-color: var(--purple-medium);
-    }
-
-    svg {
-      stroke: var(--purple);
-      margin-right: -3px;
-    }
-  }
-
-  .filter-selector-modal {
-    width: 695px;
-    max-width: 100%;
-    margin-top: 10px;
-    position: absolute;
-    right: 0;
-    z-index: 1;
-    background-color: #fff;
-    border: 1px solid var(--purple);
-    border-radius: 8px;
-
-    .filter-contents {
-      margin: 24px;
-
-      p {
-        margin-bottom: 22px;
-        text-align: left;
-        font-weight: 700;
-        font-size: 15px;
-        color: var(--black);
-      }
-    }
-
-    .close-btn {
-      position: absolute;
-      top: 12px;
-      right: 12px;
-    }
-  }
-`;
-
-const SkillFilterSelector = ({ setSkillFilter, setModalDisplay, isOpened }) => {
-  const [selectedSkillStacks, setSelectedSkillStacks] = useRecoilState(
-    selectedSkillstacksState,
-  );
-  const [isFiltered, setIsFiltered] = useState(false);
-
-  const onToggle = () => {
-    setModalDisplay();
-    if (!isFiltered) setSelectedSkillStacks([]);
-  };
-
-  const onApply = () => {
-    setSkillFilter(
-      selectedSkillStacks.map((el) => {
-        return el.name;
-      }),
-    );
-    setIsFiltered(true);
-  };
-
-  return (
-    <FilterSelectorWrapper>
-      <button
-        className={
-          isOpened ? 'filter-modal-toggle opened' : 'filter-modal-toggle'
-        }
-        onClick={() => onToggle()}
-      >
-        필터링
-        <TbFilter size={23} />
-      </button>
-      {isOpened && (
-        <div className="filter-selector-modal">
-          <div className="filter-contents">
-            <p>기술 스택으로 필터를 설정해보세요!</p>
-            <SkillStackSelect />
-          </div>
-          <ExtendedButton
-            text="적용하기"
-            onClick={() => onApply()}
-            className="apply-btn"
-          />
-          <CloseButton className="close-btn" onClick={() => onToggle()} />
-        </div>
-      )}
-    </FilterSelectorWrapper>
-  );
-};
-
+// 임시 로딩 컴포넌트
 const Loading = styled.div`
   width: 100%;
   height: 200px;

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -165,14 +165,33 @@ const LongButton = styled(DefaultButton)`
   border-radius: 0 0 8px 8px;
 `;
 
-const SkillFilterSelector = ({ onApply, onClose, isOpened }) => {
+const SkillFilterSelector = ({ setSkillFilter, setModalDisplay, isOpened }) => {
+  const [selectedSkillStacks, setSelectedSkillStacks] = useRecoilState(
+    selectedSkillstacksState,
+  );
+  const [isFiltered, setIsFiltered] = useState(false);
+
+  const onToggle = () => {
+    setModalDisplay();
+    if (!isFiltered) setSelectedSkillStacks([]);
+  };
+
+  const onApply = () => {
+    setSkillFilter(
+      selectedSkillStacks.map((el) => {
+        return el.name;
+      }),
+    );
+    setIsFiltered(true);
+  };
+
   return (
     <FilterSelectorWrapper>
       <button
         className={
           isOpened ? 'filter-modal-toggle opened' : 'filter-modal-toggle'
         }
-        onClick={() => onClose()}
+        onClick={() => onToggle()}
       >
         필터링
         <TbFilter size={23} />
@@ -188,7 +207,7 @@ const SkillFilterSelector = ({ onApply, onClose, isOpened }) => {
             onClick={() => onApply()}
             className="apply-btn"
           />
-          <CloseButton className="close-btn" onClick={onClose}>
+          <CloseButton className="close-btn" onClick={() => onToggle()}>
             <GrClose />
           </CloseButton>
         </div>
@@ -217,8 +236,7 @@ const Main = () => {
   // 전체보기/모집중만 보기 선택 토글
   const [viewAllStatus, setViewStatus] = useState(true);
   // 스킬 스택 필터
-  const [filterModalShow, setFilterModalShow] = useState(false);
-  const selectedSkillStacks = useRecoilValue(selectedSkillstacksState);
+  const [filterModalDisplay, setFilterModalDisplay] = useState(false);
   const [skillfilter, setSkillFilter] = useState([]);
   // 정렬 옵션
   const sortOptions = {
@@ -263,6 +281,8 @@ const Main = () => {
 
   // 데이터 요청 콜백
   const fetchArticles = useCallback(async () => {
+    // console.log('recoil state', articlesList);
+
     const skill = skillfilter.join(',');
     const status = viewAllStatus ? '' : false;
     const sort = sortOptions[sortOption];
@@ -275,10 +295,11 @@ const Main = () => {
     setPageNumber(data.pageInfo.page + 1);
     setHasNextPage(data.pageInfo.totalPages !== data.pageInfo.page);
     setIsFetching(false);
-    console.log('FETCH DATA!');
+    // console.log('FETCH DATA!');
+    // console.log('states:', viewAllStatus, skillfilter, sortOption, pageNumber);
   }, [viewAllStatus, skillfilter, sortOption, pageNumber]);
 
-  console.log('PAINT!');
+  // console.log('PAINT!');
   return (
     <Container>
       <h1>
@@ -297,15 +318,9 @@ const Main = () => {
             }}
           />
           <SkillFilterSelector
-            isOpened={filterModalShow}
-            onApply={() =>
-              setSkillFilter(
-                selectedSkillStacks.map((el) => {
-                  return el.name;
-                }),
-              )
-            }
-            onClose={() => setFilterModalShow(!filterModalShow)}
+            isOpened={filterModalDisplay}
+            setSkillFilter={setSkillFilter}
+            setModalDisplay={() => setFilterModalDisplay(!filterModalDisplay)}
           />
         </div>
         <div className="sort-options">
@@ -322,6 +337,7 @@ const Main = () => {
       </div>
       <ArticlesGrid>
         {articlesList.map((article) => {
+          // console.log(article.articleId, article.title);
           return (
             <ArticleCard
               key={article.articleId}

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -1,6 +1,5 @@
 import ArticleCard from '../components/ArticleCard';
 import styled from 'styled-components';
-import { GrClose } from 'react-icons/gr';
 import { TbFilter } from 'react-icons/tb';
 import { useRecoilState } from 'recoil';
 import { articlesListState, selectedSkillstacksState } from '../atom/atom';
@@ -11,6 +10,7 @@ import DefaultButton from '../components/DefaultButton';
 import SkillStackSelect from '../components/SkillStackSelect';
 import ScrollTopButton from '../components/ScrollTopButton';
 import ArticlesGrid from '../components/ArticlesGrid';
+import CloseButton from '../components/CloseButton';
 
 const Container = styled.div`
   min-height: calc(100vh - 62px);
@@ -119,39 +119,6 @@ const FilterSelectorWrapper = styled.div`
   }
 `;
 
-const CloseBtn = styled.button`
-  width: 30px;
-  height: 30px;
-  padding-top: 2px;
-  border-radius: 15px;
-  border: none;
-  background-color: transparent;
-  transition: 300ms ease-in-out;
-
-  svg path {
-    stroke: var(--purple);
-  }
-
-  &:hover {
-    background-color: var(--purple-medium);
-  }
-
-  &:active {
-    background-color: var(--purple);
-    svg path {
-      stroke: #fff;
-    }
-  }
-`;
-
-const CloseButton = ({ onClick, className }) => {
-  return (
-    <CloseBtn className={className} onClick={onClick}>
-      <GrClose />
-    </CloseBtn>
-  );
-};
-
 const LongButton = styled(DefaultButton)`
   width: calc(100% + 2px);
   margin: -1px;
@@ -200,9 +167,7 @@ const SkillFilterSelector = ({ setSkillFilter, setModalDisplay, isOpened }) => {
             onClick={() => onApply()}
             className="apply-btn"
           />
-          <CloseButton className="close-btn" onClick={() => onToggle()}>
-            <GrClose />
-          </CloseButton>
+          <CloseButton className="close-btn" onClick={() => onToggle()} />
         </div>
       )}
     </FilterSelectorWrapper>

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -10,11 +10,11 @@ import axios from 'axios';
 import SwitchToggle from '../components/SwitchToggle';
 import DefaultButton from '../components/DefaultButton';
 import SkillStackSelect from '../components/SkillStackSelect';
+import ScrollTopButton from '../components/ScrollTopButton';
 
 const Container = styled.div`
   min-height: calc(100vh - 62px);
   width: 100%;
-  margin: 0 170px;
 
   h1 {
     padding: 67px 0 77px;
@@ -330,6 +330,7 @@ const Main = () => {
           );
         })}
       </ArticlesGrid>
+      <ScrollTopButton />
       {isFetching && <Loading>게시글 불러오는 중...</Loading>}
     </Container>
   );

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -66,17 +66,17 @@ const ArticlesGrid = styled.div`
 
 const FilterSelectorWrapper = styled.div`
   .filter-modal-toggle {
-    width: 100px;
     height: 36px;
     margin-left: 10px;
     padding-left: 4px;
 
     background-color: var(--purple-light);
-    border: solid 1px var(--purple);
+    border: solid 2px var(--purple);
     border-radius: 20px;
+    padding: 0 0.9em;
 
-    font-weight: 400;
-    font-size: 15px;
+    font-weight: 700;
+    font-size: 13px;
     color: var(--purple);
 
     transition: 300ms ease-in-out;
@@ -87,6 +87,11 @@ const FilterSelectorWrapper = styled.div`
 
     &.opened {
       background-color: var(--purple-medium);
+    }
+
+    svg {
+      stroke: var(--purple);
+      margin-right: -3px;
     }
   }
 
@@ -170,7 +175,7 @@ const SkillFilterSelector = ({ onApply, onClose, isOpened }) => {
         onClick={() => onClose()}
       >
         필터링
-        <TbFilter />
+        <TbFilter size={23} />
       </button>
       {isOpened && (
         <div className="filter-selector-modal">
@@ -285,7 +290,7 @@ const Main = () => {
           <SwitchToggle
             left="전체 보기"
             right="모집 중"
-            checked={viewAllStatus}
+            setChecked={viewAllStatus}
             width="100px"
             onClick={() => {
               setViewStatus(!viewAllStatus);

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -218,7 +218,7 @@ const Main = () => {
   const [viewAllStatus, setViewStatus] = useState(true);
   // 스킬 스택 필터
   const [filterModalShow, setFilterModalShow] = useState(false);
-  const selectedSkillstacks = useRecoilValue(selectedSkillstacksState);
+  const selectedSkillStacks = useRecoilValue(selectedSkillstacksState);
   const [skillfilter, setSkillFilter] = useState([]);
   // 정렬 옵션
   const sortOptions = {
@@ -298,7 +298,13 @@ const Main = () => {
           />
           <SkillFilterSelector
             isOpened={filterModalShow}
-            onApply={() => setSkillFilter(selectedSkillstacks)}
+            onApply={() =>
+              setSkillFilter(
+                selectedSkillStacks.map((el) => {
+                  return el.name;
+                }),
+              )
+            }
             onClose={() => setFilterModalShow(!filterModalShow)}
           />
         </div>


### PR DESCRIPTION
구현된 모습입니다😀 
![메인페이지](https://user-images.githubusercontent.com/77370965/203887874-32bea9e0-5f59-4ba0-a526-f13cf4ee35c3.gif)

(위에서는 화질 문제인지 흰색이 잘 안보이지만, 실제로는 이렇게 나옵니다!)
<img width="1390" alt="Screen Shot 2022-11-25 at 11 56 29 AM" src="https://user-images.githubusercontent.com/77370965/203891535-2bec576d-3e0b-453d-b6e9-09ae6c5afaf1.png">

### ✅ atom.js
- 게시글 목록 데이터를 articlesListState에 저장합니다. (현재는 목록을 순회하며 ArticleCard에 props로 전달하고 있어 전역상태까지는 필요 없을 듯도 하지만, 리팩토링에서 아티클 목록을 순회하는 부분까지 컴포넌트에 적용하면 좋을 것 같아 우선 전역으로 설정했습니다!

### ✅ Main.js
- 무한 스크롤은 스크롤 이벤트를 감지해서 발생합니다. 쉽게 이해할 수 있는 방식이지만, 성능이 좋지 않다고 하여 리팩토링을 해야할 것 같습니다. (참고한 링크: https://tech.kakaoenterprise.com/149)
- 로딩 바는 임시로 문구와 애니메이션을 넣어뒀습니다!

### ✅ 추가/수정된 컴포넌트 
- **ArticlesGrid**: 아티클 목록을 감싸는 그리드입니다. 화면 너비에 따라 줄당 아티클 수가 결정되고, 각 아티클의 크기는 최소 323px에서 최대 1/4 width입니다. (지금은 아티클 카드 자체 너비가 323px 고정이지만 100%로 수정하면 화면 너비에 따라 달라집니다! 아티클 카드를 사용하는 다른 페이지에서도 그리드 적용 후 카드 너비를 100%로 수정하면 좋을 것 같습니다!)
- **SkillFilterSelector**: 스킬 필터 선택 모달입니다. 
- **CloseButton**: 스킬 스택 선택 모달의 닫기 버튼입니다. 다른 모달에서도 활용할 수 있을 듯 합니다. 
-  **ExtendedButton**: 스킬 선택 모달의 적용하기 버튼에 사용됩니다. 모달 하단을 감싸는 형태입니다!
- **DefaultButton**(수정): font-weight가 실제 적용했을 때 너무 굵어서 700으로 줄였습니다. 스타일에 대한 추가 수정은 extends로 해도 좋지만, position 설정같은 부분은 className으로 간단히 하면 좋을 것 같아 props로 className을 받아 적용할 수 있도록 수정했습니다.
- **Header**(수정): 스킬 선택 모달에 z-index가 1로 설정되어 Header는  z-index를 2로 높였습니다. 
- **ScrollTopButton**(수정): 크기, 위치, 등장 애니메이션을 설정했습니다. 눈에 띄도록 스타일을 변경하는 것도 좋을 듯 싶습니다. 

### 🐞 버그 
- 메인페이지에 새로고침이 아닌 Link를 통해 돌아왔을 때, articlesListState가 저장되어 있던 상태를 유지한 채로 데이터를 덧붙여 아티클이 중복되는 버그가 있습니다. 
- 스킬 필터 적용, 재선택(적용X)후 모달을 닫고 다시 열면 필터에 적용된 태그가 아닌 재선택된 태그들을 보여줍니다. 모달을 닫을 때 실제 적용된 필터로 선택된 태그 state를 변경해줘야 하는데, 두 state에 저장되는 형식이 달라 우선 남겨뒀습니다. 태그가 state에 저장되는 형식을 리팩토링하고 해결하면 좋을 것 같습니다.  
- 화면 크기 재조정을 해도 변화가 없고, 하단까지 스크롤을 해야 새로 데이터를 받아옵니다. 받아오는 페이지의 번호는 유지되지만, 아티클의 갯수는 화면 너비에 따라 달라지기 때문에 아티클 중복/누락 문제가 발생할 수 있습니다.