### PR TITLE
feat: 비밀번호 찾기 기능 구현

### DIFF
--- a/client/src/atom/atom.js
+++ b/client/src/atom/atom.js
@@ -195,3 +195,9 @@ export const isCompletedState = atom({
   key: 'isCompletedState',
   default: false,
 });
+
+// 비밀번호 찾기위한 이메일 입력 값 상태
+export const searchPwEmailState = atom({
+  key: 'searchPwEmailState',
+  default: '',
+});

--- a/client/src/components/DefaultInput.js
+++ b/client/src/components/DefaultInput.js
@@ -23,12 +23,22 @@ const Input = styled.input`
   }
 `;
 
-const DefaultInput = ({ placeholder, value, onChange, width, height }) => {
+const DefaultInput = ({
+  placeholder,
+  value,
+  onChange,
+  onblur,
+  width,
+  height,
+}) => {
   return (
     <Input
       placeholder={placeholder}
       value={value}
-      onChange={(e) => onChange(e.target.value)}
+      onChange={(e) => {
+        onChange(e.target.value);
+      }}
+      onBlur={(e) => onblur(e.target.value)}
       width={width}
       height={height}
     />

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -17,7 +17,6 @@ import {
   modalOpenState,
 } from '../atom/atom';
 
-
 const HeaderContainer = styled.header`
   z-index: 1;
   width: 100%;

--- a/client/src/components/SwitchToggle.js
+++ b/client/src/components/SwitchToggle.js
@@ -90,7 +90,6 @@ const CheckBox = styled.input`
 `;
 
 const SwitchToggle = ({ right, setChecked, onClick }) => {
-  console.log(setChecked);
   return (
     <ToggleContainer checked={setChecked} width="100px">
       <CheckBoxContainer>
@@ -101,7 +100,6 @@ const SwitchToggle = ({ right, setChecked, onClick }) => {
           type="checkbox"
           checked={setChecked}
           onClick={onClick}
-          checked={setChecked}
         ></CheckBox>
       </CheckBoxContainer>
     </ToggleContainer>


### PR DESCRIPTION
#83 

- atom
  - 비밀번호를 찾기 위해 입력하는 이메일 정보를 저장할 상태를 추가했습니다.
- DefaultInput
  - 유효성 검사를 포커스해제 됐을 때 하기 위해 onblur props를 추가했습니다.
- Header
  - 빈칸 prettier를 실행하니까 삭제되어있어서 변화가 생겼으나, 변한 코드는 없습니다!
- SwitchToggle
  - 오전에 머지하면서 checked 변수가 2개 중복되어들어간 것 같아 삭제해주었습니다.
- Login
  - isSearchPw는 비밀번호찾기클릭 여부를 관리하는 상태,
    searchPwEmail은 서버에 보낼 이메일 값을 담은 상태(전역),
    noticeText는 안내문구 값을 담은 상태,
    isNotice는 안내문구 표시 여부를 관리하는 상태,

  - 비밀번호 찾기를 클릭하면 소셜로그인 대신 찾기 입력란이 표시되도록 수정해봤습니다.
  - 일단 임시로 email 정규표현식을 할당해놨는데, 
  나중에 회원가입 PR 하시면 회원가입의 이메일 정규표현식으로 수정하면 좋을 것 같습니다.

![PR 비밀번호 찾기 구현](https://user-images.githubusercontent.com/107869548/204549894-241a4ba0-f89e-48d5-b8f0-0b83b2b920ee.gif)
