### PR TITLE
Design: 아티클 카드 수정 및 그리드 적용

### DIFF
--- a/client/src/components/ArticleCard.js
+++ b/client/src/components/ArticleCard.js
@@ -6,7 +6,7 @@ import yearMonthDate from '../utils/dateFormat';
 
 const ArticleCardWrapper = styled(Link)`
   display: inline-block;
-  width: 323px;
+  width: 100%;
   height: 286px;
   border-radius: 25px;
   background-color: #ffffff;
@@ -108,6 +108,7 @@ const ArticleCardWrapper = styled(Link)`
     height: 26px;
 
     li {
+      height: 100%;
       padding: 4px 10px;
       border-radius: 13px;
       font-weight: 700;

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -15,6 +15,7 @@ import { useRecoilState, useSetRecoilState, useRecoilValue } from 'recoil';
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 import getSkills from '../utils/getSkills';
+import ArticlesGrid from '../components/ArticlesGrid';
 
 const Container = styled.div`
   min-height: calc(100vh - 62px); //전체화면-헤더 높이
@@ -207,8 +208,7 @@ const MyPage = () => {
             );
           })}
         </ul>
-
-        <ul className="article-list">
+        <ArticlesGrid>
           {tabContArr[activeMenu].tabCont.map((article, idx) => {
             return (
               <ArticleCard
@@ -228,7 +228,7 @@ const MyPage = () => {
               />
             );
           })}
-        </ul>
+        </ArticlesGrid>
       </div>
     </Container>
   );

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -13,6 +13,7 @@ import { useRecoilState, useSetRecoilState } from 'recoil';
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import axios from 'axios';
+import ArticlesGrid from '../components/ArticlesGrid';
 
 const Container = styled.div`
   min-height: calc(100vh - 62px); //전체화면-헤더 높이
@@ -194,7 +195,7 @@ const Profile = () => {
           </div>
         </ul>
 
-        <ul className="article-list">
+        <ArticlesGrid>
           {recruitedArticles.map((article, idx) => {
             return (
               <ArticleCard
@@ -214,7 +215,7 @@ const Profile = () => {
               />
             );
           })}
-        </ul>
+        </ArticlesGrid>
       </div>
     </Container>
   );

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -216,6 +216,7 @@ const SignUp = () => {
   };
   // 깃허브 연동하기
   const onConnectGithub = () => {
+    alert('준비중인 기능입니다!');
     // axios.get(`/oauth2/authorization/github`).then((res) => console.log(res));
   };
   // 전체 내용 확인


### PR DESCRIPTION
- 아티클 카드의 스킬 태그가 두줄로 넘어가면 아랫줄의 태그가 살짝 보여서 스킬 태그 높이를 설정했습니다. 
- 프로필 상세 페이지, 마이페이지에 아티클 그리드를 적용했고, 아티클 카드의 너비를 그리드 내에서 100% 차지하도록 수정했습니다!