### PR TITLE
Feat: 회원가입 페이지 내 깃허브 연동 기능 구현

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -8,6 +8,7 @@ import MyPage from './pages/MyPage';
 import MyPageEdit from './pages/MyPageEdit';
 import Profile from './pages/Profile';
 import SignUp from './pages/SignUp';
+import ReceiveGithub from './pages/ReceiveGithub';
 import styled from 'styled-components';
 
 const Container = styled.div`
@@ -36,6 +37,7 @@ function App() {
             <Route path="/mypage/edit/:id" element={<MyPageEdit />} />
             <Route path="/profile/:id" element={<Profile />} />
             <Route path="/signup" element={<SignUp />} />
+            <Route path="/receive-token.html" element={<ReceiveGithub />} />
           </Routes>
         </ContentContainer>
       </Container>

--- a/client/src/atom/atom.js
+++ b/client/src/atom/atom.js
@@ -196,7 +196,6 @@ export const isCompletedState = atom({
   default: false,
 });
 
-
 // 숙련도 선택 상태
 export const selectedLevelState = atom({
   key: 'selectedLevelState',
@@ -213,7 +212,7 @@ export const activeDropDownState = atom({
 export const levelOptionsState = atom({
   key: 'levelOptionsState',
   default: [],
-  });
+});
 
 // 비밀번호 찾기위한 이메일 입력 값 상태
 export const searchPwEmailState = atom({

--- a/client/src/components/LineInput.js
+++ b/client/src/components/LineInput.js
@@ -13,6 +13,8 @@ const Input = styled.input`
   border: none;
   border-bottom: 1px solid;
   border-color: ${(props) => (props.isError ? 'red' : 'var(--purple)')};
+  font-size: 14px;
+  color: var(--black);
 
   &:focus {
     outline: none;

--- a/client/src/components/MiniButton.js
+++ b/client/src/components/MiniButton.js
@@ -2,11 +2,11 @@ import styled from 'styled-components';
 
 const Button = styled.button`
   height: 36px;
-  background-color: var(--purple-light);
+  background-color: ${(props) => props.bgColor || 'var(--purple-light)'};
   padding: 8px 10px;
   border-radius: 8px;
   border: none;
-  color: var(--purple);
+  color: ${(props) => props.color || 'var(--purple)'};
   border: 1px solid var(--purple);
   font-size: 15px;
   font-weight: 500;
@@ -21,14 +21,19 @@ const Button = styled.button`
   }
 
   &:active {
-    background-color: var(--purple);
-    color: var(--purple-light);
+    background-color: ${(props) => props.color || 'var(--purple)'};
+    color: ${(props) => props.bgColor || 'var(--purple-light)'};
   }
 `;
 
-const MiniButton = ({ text, disabled, onClick }) => {
+const MiniButton = ({ text, disabled, onClick, color, bgColor }) => {
   return (
-    <Button disabled={disabled} onClick={onClick}>
+    <Button
+      disabled={disabled}
+      onClick={onClick}
+      color={color}
+      bgColor={bgColor}
+    >
       {text}
     </Button>
   );

--- a/client/src/pages/ReceiveGithub.js
+++ b/client/src/pages/ReceiveGithub.js
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import styled from 'styled-components';
+import { AiOutlineCheck } from 'react-icons/ai';
+import DefaultButton from '../components/DefaultButton';
+
+const Container = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 30;
+  padding-top: 100px;
+  text-align: center;
+  background-color: var(--purple-light);
+  color: var(--purple);
+
+  .check-icon {
+    width: 60px;
+    height: 60px;
+    margin-bottom: 40px;
+    padding: 15px 10px 10px;
+    border-radius: 50%;
+    background-color: var(--purple);
+  }
+
+  p {
+    margin-bottom: 40px;
+  }
+`;
+
+const ReceiveGithub = () => {
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const githubURL = url.searchParams.get('github');
+    if (githubURL) {
+      localStorage.setItem('githubURL', githubURL);
+      window.close();
+      return githubURL;
+    }
+  }, []);
+
+  return (
+    <Container>
+      <AiOutlineCheck className="check-icon" fill="#fff" />
+      <p>
+        깃허브 인증이 완료되었습니다!
+        <br />
+        페이지로 돌아가주세요.
+      </p>
+      <DefaultButton text="돌아가기" onClick={() => window.close()} />
+    </Container>
+  );
+};
+
+export default ReceiveGithub;

--- a/client/src/pages/ReceiveGithub.js
+++ b/client/src/pages/ReceiveGithub.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { AiOutlineCheck } from 'react-icons/ai';
 import DefaultButton from '../components/DefaultButton';
@@ -13,7 +13,6 @@ const Container = styled.div`
   padding-top: 100px;
   text-align: center;
   background-color: var(--purple-light);
-  color: var(--purple);
 
   .check-icon {
     width: 60px;
@@ -24,29 +23,44 @@ const Container = styled.div`
     background-color: var(--purple);
   }
 
+  h1 {
+    margin-bottom: 10px;
+    font-size: 20px;
+    color: var(--black);
+  }
+
   p {
     margin-bottom: 40px;
+    color: var(--purple);
   }
 `;
 
 const ReceiveGithub = () => {
+  const [time, setTime] = useState(3);
+
+  const url = new URL(window.location.href);
+  const githubURL = url.searchParams.get('github');
+
   useEffect(() => {
-    const url = new URL(window.location.href);
-    const githubURL = url.searchParams.get('github');
+    if (time === 0) window.close();
     if (githubURL) {
       localStorage.setItem('githubURL', githubURL);
-      window.close();
-      return githubURL;
+      setInterval(() => {
+        setTime(time - 1);
+      }, 1000);
     }
-  }, []);
+  }, [time]);
 
   return (
     <Container>
       <AiOutlineCheck className="check-icon" fill="#fff" />
-      <p>
+      <h1>
         깃허브 인증이 완료되었습니다!
         <br />
         페이지로 돌아가주세요.
+      </h1>
+      <p>
+        <strong>{time}</strong>초 후 자동으로 돌아갑니다.
       </p>
       <DefaultButton text="돌아가기" onClick={() => window.close()} />
     </Container>

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -43,20 +43,6 @@ const Container = styled.div`
       justify-content: space-between;
     }
 
-    .select-section {
-      margin-bottom: 30px;
-    }
-
-    .github-link {
-      display: flex;
-      align-items: center;
-
-      span {
-        font-size: 13px;
-        font-weight: 400;
-      }
-    }
-
     .input-wrapper {
       display: flex;
 
@@ -69,11 +55,29 @@ const Container = styled.div`
         padding-top: 5px;
       }
     }
+
+    .select-section {
+      margin-bottom: 30px;
+
+      .option-notice {
+        font-size: 13px;
+        font-weight: 400;
+      }
+    }
   }
 
   .submit-btn {
     margin-top: 60px;
     float: right;
+  }
+
+  .github-url {
+    width: 100%;
+    color: var(--black);
+    line-height: 10px;
+    padding-top: 12px;
+    border-bottom: 1px solid var(--purple);
+    font-size: 14px;
   }
 `;
 
@@ -109,6 +113,7 @@ const SignUp = () => {
     useRecoilState(interestsCheckState);
 
   const [github, setGithub] = useState('');
+  const [githubIsChecked, setGithubChecked] = useState(false);
 
   // 내용 수정
   // 아이디
@@ -219,16 +224,25 @@ const SignUp = () => {
   // 깃허브 연동하기
   const onConnectGithub = () => {
     const githubPopup = window.open(
-      'http://ec2-15-165-2-129.ap-northeast-2.compute.amazonaws.com:8080/oauth2/authorization/github',
+      process.env.REACT_APP_OAUTH_GITHUB_URL,
       '깃허브 인증창',
       'width=600px,height=500px,scrollbars=yes',
     );
     githubPopup.addEventListener('unload', () => {
       const githubURL = window.localStorage.getItem('githubURL');
-      setGithub(githubURL);
+      if (githubURL) {
+        window.alert('깃허브 계정이 연동되었습니다!');
+        setGithub(githubURL);
+        setGithubChecked(true);
+      }
     });
   };
-
+  // 깃허브 연동 해제
+  const onDisconnectGithub = () => {
+    window.localStorage.removeItem('githubURL');
+    setGithub('');
+    setGithubChecked(false);
+  };
   // 전체 내용 확인
   const onCheckAll = () => {
     onIdValidation();
@@ -414,11 +428,30 @@ const SignUp = () => {
             )}
             <InterestSelect id="interest" />
           </div>
-          <div className="select-section github-link">
+          <div className="select-section">
             <Label htmlFor="github">
-              깃허브<span>(선택)</span>
+              깃허브<span className="option-notice">(선택)</span>
             </Label>
-            <MiniButton text="연동하기" onClick={onConnectGithub} />
+            <div className="input-wrapper">
+              <p className="github-url" id="github">
+                {githubIsChecked ? github : '깃허브 계정을 연동해주세요!'}
+              </p>
+              {githubIsChecked ? (
+                <>
+                  <div className="confirmed-icon">
+                    <AiOutlineCheck fill="var(--purple)" />
+                  </div>
+                  <MiniButton
+                    text="해제하기"
+                    onClick={onDisconnectGithub}
+                    color="var(--purple-light)"
+                    bgColor="var(--purple)"
+                  />
+                </>
+              ) : (
+                <MiniButton text="연동하기" onClick={onConnectGithub} />
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -292,6 +292,7 @@ const SignUp = () => {
         .then(() => {
           window.alert('가입되었습니다'); // 로그인 요청 추가시 환영 문구로 변경 필요
           window.location = '/';
+          window.localStorage.removeItem('githubURL');
         })
         .catch((err) => {
           if (err.response.data.status === 409) {

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -108,6 +108,8 @@ const SignUp = () => {
   const [interestsCheck, setInterestsCheck] =
     useRecoilState(interestsCheckState);
 
+  const [github, setGithub] = useState('');
+
   // 내용 수정
   // 아이디
   const onIdChange = (id) => {
@@ -216,9 +218,17 @@ const SignUp = () => {
   };
   // 깃허브 연동하기
   const onConnectGithub = () => {
-    alert('준비중인 기능입니다!');
-    // axios.get(`/oauth2/authorization/github`).then((res) => console.log(res));
+    const githubPopup = window.open(
+      'http://ec2-15-165-2-129.ap-northeast-2.compute.amazonaws.com:8080/oauth2/authorization/github',
+      '깃허브 인증창',
+      'width=600px,height=500px,scrollbars=yes',
+    );
+    githubPopup.addEventListener('unload', () => {
+      const githubURL = window.localStorage.getItem('githubURL');
+      setGithub(githubURL);
+    });
   };
+
   // 전체 내용 확인
   const onCheckAll = () => {
     onIdValidation();
@@ -261,11 +271,11 @@ const SignUp = () => {
         memberInterests,
         memberSkills,
       };
+      if (github.length > 1) signUpInfo.github = github;
 
       axios
         .post('/members/signup', signUpInfo)
         .then(() => {
-          // + 입력되어 있던 데이터로 로그인 요청
           window.alert('가입되었습니다'); // 로그인 요청 추가시 환영 문구로 변경 필요
           window.location = '/';
         })


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2022-12-02 at 12 01 42 AM" src="https://user-images.githubusercontent.com/77370965/205087066-28f2dcb8-b8ec-4304-8bed-198ebb5a6ed3.png">

> 흐름을 설명 드리자면,,,
> 1. 연동하기 버튼을 누르면 백엔드에서 인증을 진행해주시는 주소로 새로 창을 띄웁니다. 
> 2. 정확한 로직은 모르지만 바로 깃허브 로그인(연동) 페이지로 넘어갑니다. 로그인을 진행해 3355앱에 엑세스 허용을 선택할 경우 localhost:3000/receive-token.html으로 돌아갑니다. 현재 localhost:3000/receive-token.html 루트로는 따로 만들어둔 ReceiveGithub 페이지를 보여줍니다. (위 화면에 팝업창입니다!!)
> 3. ReceiveGithub 페이지에서는 parameter로 들어온 깃허브 주소가 있다면 로컬호스트에 저장합니다. (3초 후 자동으로 닫힙니다)
> 4. 연동하기 버튼에서 receive-token.html 페이지를 열 때 unload 이벤트 리스너를 등록해뒀기 때문에, 창이 닫히면 로컬 스토리지에 저장된 깃허브 주소를 가져옵니다! 
> 5. 깃허브 주소가 있다면 가져온 주소 정보를 state에 저장하고 깃허브 체크 상태를 변경합니다. state변경에 따라 기본 안내 문구 + 연동하기 버튼 → 깃허브 주소 + 해제하기 버튼으로 변경됩니다.


- 로그인 성공했을 때는 ReceiveGithub으로 가지만, 실패시 페이지는 아직 없어서 기본 에러 페이지..? 로 가게 됩니다. 
- 이미 계정을 연동한 사용자의 경우 token값과 memberId가 오는데, 이 부분에 대해서는 아직 대응을 못했습니다. 깃허브 로그인 작업하면서 생각해봐야 할 것 같아요!
- 연동해제 요청에 memberId가 필요한데, 아직 회원가입 전이라 memberId가 없습니다... 백엔드 분들과 의논이 필요할 것 같아요. 일단은 state와 로컬 스토리지만 초기화하도록 했습니다. 
- 바로 링크로 연결되기 때문에 프록시 설정이 이 부분에서는 필요없는 것 같아서, 인증 요청 주소를 env파일에 설정해두었습니다! 아침에 디코로 공유드리겠습니다🥰
- 지금은 연동 성공시 로컬호스트:3000/ /receive-token.html으로 리다이렉트 설정을 해두셨다고 합니다. 주소를 하나만 설정할 수 있어서, 배포하게 되면 주소 변경이 필요합니다. 그리고 receive-token.html 루트 이름도 더 적절한 이름이 있다면 변경 부탁드리면 될 것 같습니다. (추천받아요,,,!😚)
- 우선은 팝업창처럼 뜰 수 있게 해봤는데, 이게 브라우저마다 어떻게 뜰지 확신은 안되네요,,😭 안되면 다른 탭을 여는 방법으로 해야 할 듯 싶습니다. 


수정사항이나 아이디어가 있다면 언제든 편하게 알려주세요!🙇‍♀️
#94 