### PR TITLE
Fix: 메인페이지 버그 수정 

### DIFF
--- a/client/src/atom/atom.js
+++ b/client/src/atom/atom.js
@@ -94,12 +94,6 @@ export const inputHashTagsState = atom({
   default: [],
 });
 
-// 게시글 목록
-export const articlesListState = atom({
-  key: 'articlesListState',
-  default: [],
-});
-
 // 사용자가 모집한 프로젝트 목록 상태
 export const recruitedArticlesState = atom({
   key: 'recruitedArticlesState',
@@ -196,7 +190,6 @@ export const isCompletedState = atom({
   default: false,
 });
 
-
 // 숙련도 선택 상태
 export const selectedLevelState = atom({
   key: 'selectedLevelState',
@@ -213,7 +206,7 @@ export const activeDropDownState = atom({
 export const levelOptionsState = atom({
   key: 'levelOptionsState',
   default: [],
-  });
+});
 
 // 비밀번호 찾기위한 이메일 입력 값 상태
 export const searchPwEmailState = atom({

--- a/client/src/components/ArticleCard.js
+++ b/client/src/components/ArticleCard.js
@@ -14,7 +14,7 @@ const ArticleCardWrapper = styled(Link)`
   position: relative;
 
   &:hover {
-    box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
+    box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
     transform: translate(0, -5px);
   }
 

--- a/client/src/components/ScrollTopButton.js
+++ b/client/src/components/ScrollTopButton.js
@@ -6,11 +6,12 @@ const Button = styled.button`
   position: fixed;
   bottom: 100px;
   right: 100px;
-  width: 57px;
-  height: 57px;
+  width: 60px;
+  height: 60px;
   background-color: #ffffff;
   border-radius: 50%;
   border: none;
+  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
   animation: fadein 1s alternate;
 
   @keyframes fadein {

--- a/client/src/components/SkillFilterSelector.js
+++ b/client/src/components/SkillFilterSelector.js
@@ -81,6 +81,7 @@ const SkillFilterSelector = ({ setSkillFilter, setModalDisplay, isOpened }) => {
   };
 
   const onApply = () => {
+    setModalDisplay();
     setSkillFilter(
       selectedSkillStacks.map((el) => {
         return el.name;

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -87,7 +87,7 @@ const Main = () => {
   // 데이터 요청 옵션
   const [pageNumber, setPageNumber] = useState(1);
   const [hasNextPage, setHasNextPage] = useState(true);
-  const pageSize = 3 * Math.floor((visualViewport.width - 340) / (323 + 30));
+  const [viewPortWidth, setViewPortWidth] = useState(visualViewport.width);
 
   // 스크롤 감지
   useEffect(() => {
@@ -97,9 +97,16 @@ const Main = () => {
         setIsFetching(true);
       }
     };
+    const handleResize = () => {
+      setViewPortWidth(visualViewport.width);
+    };
     setIsFetching(true);
     window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleResize);
+    };
   }, []);
 
   // 필터링/정렬 변화
@@ -118,6 +125,8 @@ const Main = () => {
 
   // 데이터 요청 콜백
   const fetchArticles = useCallback(async () => {
+    const pageSize = 3 * Math.floor((viewPortWidth - 340) / (323 + 30));
+
     const skill = skillfilter.join(',');
     const status = viewAllStatus ? '' : false;
     const sort = sortOptions[sortOption];
@@ -130,11 +139,8 @@ const Main = () => {
     setPageNumber(data.pageInfo.page + 1);
     setHasNextPage(data.pageInfo.totalPages !== data.pageInfo.page);
     setIsFetching(false);
-    // console.log('FETCH DATA!');
-    // console.log('states:', viewAllStatus, skillfilter, sortOption, pageNumber);
-  }, [viewAllStatus, skillfilter, sortOption, pageNumber]);
+  }, [viewAllStatus, skillfilter, sortOption, pageNumber, viewPortWidth]);
 
-  // console.log('PAINT!');
   return (
     <Container>
       <h1>

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -125,7 +125,7 @@ const Main = () => {
 
   // 데이터 요청 콜백
   const fetchArticles = useCallback(async () => {
-    const pageSize = 3 * Math.floor((viewPortWidth - 340) / (323 + 30));
+    const pageSize = 3 * Math.floor((viewPortWidth - 340 + 30) / (323 + 30));
 
     const skill = skillfilter.join(',');
     const status = viewAllStatus ? '' : false;
@@ -150,8 +150,7 @@ const Main = () => {
       <div className="view-options">
         <div className="filter-options">
           <SwitchToggle
-            left="전체 보기"
-            right="모집 중"
+            right="전체 보기"
             setChecked={viewAllStatus}
             width="100px"
             onClick={() => {

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -150,7 +150,7 @@ const Main = () => {
       <div className="view-options">
         <div className="filter-options">
           <SwitchToggle
-            right="전체 보기"
+            right="모두 보기"
             setChecked={viewAllStatus}
             width="100px"
             onClick={() => {

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -1,7 +1,5 @@
 import ArticleCard from '../components/ArticleCard';
 import styled from 'styled-components';
-import { useRecoilState } from 'recoil';
-import { articlesListState } from '../atom/atom';
 import { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import SwitchToggle from '../components/SwitchToggle';
@@ -71,7 +69,7 @@ const Loading = styled.div`
 
 const Main = () => {
   // 아티클 목록
-  const [articlesList, setArticlesList] = useRecoilState(articlesListState);
+  const [articlesList, setArticlesList] = useState([]);
   // 전체보기/모집중만 보기 선택 토글
   const [viewAllStatus, setViewStatus] = useState(true);
   // 스킬 스택 필터
@@ -120,8 +118,6 @@ const Main = () => {
 
   // 데이터 요청 콜백
   const fetchArticles = useCallback(async () => {
-    // console.log('recoil state', articlesList);
-
     const skill = skillfilter.join(',');
     const status = viewAllStatus ? '' : false;
     const sort = sortOptions[sortOption];
@@ -176,7 +172,6 @@ const Main = () => {
       </div>
       <ArticlesGrid>
         {articlesList.map((article) => {
-          // console.log(article.articleId, article.title);
           return (
             <ArticleCard
               key={article.articleId}


### PR DESCRIPTION
☺️수정된 내용은 다음과 같습니다: 
- 페이지 이동 후 돌아왔을 때 게시글 중복 버그 → 전역 상태의 값이 유지되면서 발생한 문제입니다. 우선은 useState로 교체했습니다. 리팩토링시 전역 상태로 관리할 수 있는 방법을 알게 된다면, 현재 각 페이지에서 게시글 카드에 props로 값을 전달하는 부분도 컴포넌트로 옮길 수 있을 것 같습니다!
- 화면 크기 조정시 게시글 누락/중복 버그 → 화면 너비에 대한 상태를 만들고 디스플레이 영역 변경을 감지하는 이벤트 리스너를 통해 상태를 변경하도록 했습니다. 
- 게시글 갯수 연산식 수정 → 그리드 gap을 게시글 카드 개수와 동일하게 세고 있어서 게시글을 필요한 수보다 적게 불러오는 버그가 있었습니다. 기존 계산법에 gap으로 설정된 30px만큼 전체 영역에 더해주었습니다. 
- 토글 버튼 문구 수정 → 모집중/모두 보기 로 변경했습니다.
- 필터 적용시 필터 창 닫는 기능 추가 → 멘토님이 조언해주신 대로 수정했습니다! 덕분에 실제 적용된 필터를 따로 판별할 필요가 없어졌습니다:) 