### PR TITLE
Feat: 깃허브 소셜 로그인 기능 구현

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -172,6 +172,7 @@ const Header = () => {
   const onLogOut = () => {
     localStorage.removeItem('Authorization');
     localStorage.removeItem('Refresh');
+    localStorage.removeItem('memberId');
     setCurrentUser({ memberId: null, isLogIn: false });
     notiSuccess('로그아웃 되었습니다.');
     navigate('/');

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -154,29 +154,31 @@ const Header = () => {
     setInputBodyCheck(true);
     setHashtagsCheck(true);
   };
-  const onLogIn = () => {
-    setModalOpen(!modalOpen);
-    setMenu(3);
-  };
 
   const onMyPage = () => {
     navigate(`/mypage/${currentUser.memberId}`);
     setMenu(3);
   };
 
-  const onSignup = () => {
-    navigate('/signup');
-    setMenu(4);
-  };
-
   const onLogOut = () => {
+    setMenu(4);
     localStorage.removeItem('Authorization');
     localStorage.removeItem('Refresh');
     localStorage.removeItem('memberId');
     setCurrentUser({ memberId: null, isLogIn: false });
     notiSuccess('로그아웃 되었습니다.');
     navigate('/');
-    setMenu(4);
+    setMenu(0);
+  };
+
+  const onLogIn = () => {
+    setModalOpen(!modalOpen);
+    setMenu(5);
+  };
+
+  const onSignup = () => {
+    navigate('/signup');
+    setMenu(6);
   };
 
   const userMenu = useRef();
@@ -236,12 +238,12 @@ const Header = () => {
             ) : (
               <>
                 <li>
-                  <NavBtn $color={menu === 3} onClick={onLogIn}>
+                  <NavBtn $color={menu === 5} onClick={onLogIn}>
                     로그인
                   </NavBtn>
                 </li>
                 <li>
-                  <NavBtn $color={menu === 4} onClick={onSignup}>
+                  <NavBtn $color={menu === 6} onClick={onSignup}>
                     회원가입
                   </NavBtn>
                 </li>{' '}

--- a/client/src/pages/LogIn.js
+++ b/client/src/pages/LogIn.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { useState } from 'react';
 import axios from 'axios';
-import { useSetRecoilState, useRecoilState } from 'recoil';
+import { useSetRecoilState, useRecoilState, useRecoilValue } from 'recoil';
 import {
   modalOpenState,
   searchPwEmailState,
@@ -233,7 +233,7 @@ const LogIn = ({ userMenu }) => {
           setEmail('');
           setPassword('');
           closeLogIn();
-          notiSuccess('로그인 완료 되었습니다.');
+          notiSuccess('로그인 되었습니다!');
         })
         .catch((ex) => {
           // 요청 후 서버에 이메일 존재하지 않아 404에러 발생시 실행
@@ -244,6 +244,29 @@ const LogIn = ({ userMenu }) => {
     }
   };
 
+  const onGithubLogin = () => {
+    const githubPopup = window.open(
+      process.env.REACT_APP_OAUTH_GITHUB_URL,
+      '깃허브 인증창',
+      'width=600px,height=500px,scrollbars=yes',
+    );
+    githubPopup.addEventListener('unload', () => {
+      const memberId = window.localStorage.getItem('memberId');
+      const Authorization = window.localStorage.getItem('Authorization');
+      const githubURL = window.localStorage.getItem('githubURL');
+
+      if (Authorization) {
+        setCurrentUser({ memberId, isLogIn: true });
+        notiSuccess('로그인 되었습니다!');
+      } else if (githubURL) {
+        notiError(
+          '등록된 깃허브 계정이 아닙니다! 회원가입 후 깃허브 계정을 연동해주세요',
+        );
+      }
+    });
+  };
+  const currentUser = useRecoilValue(currentUserState);
+  console.log(currentUser);
   return (
     <Container>
       <div className="login-container" ref={userMenu}>
@@ -328,19 +351,19 @@ const LogIn = ({ userMenu }) => {
             <Authbutton href="">
               <img
                 src={require('../images/google login.png')}
-                alt="구글로그인"
+                alt="구글 로그인"
               ></img>
             </Authbutton>
-            <Authbutton href="">
+            <Authbutton onClick={onGithubLogin}>
               <img
                 src={require('../images/github login.png')}
-                alt="깃허브로그인"
+                alt="깃허브 로그인"
               ></img>
             </Authbutton>
             <Authbutton href="">
               <img
                 src={require('../images/kakao login.png')}
-                alt="카카오톡로그인"
+                alt="카카오톡 로그인"
               ></img>
             </Authbutton>
           </div>

--- a/client/src/pages/LogIn.js
+++ b/client/src/pages/LogIn.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { useState } from 'react';
 import axios from 'axios';
-import { useSetRecoilState, useRecoilState, useRecoilValue } from 'recoil';
+import { useSetRecoilState, useRecoilState } from 'recoil';
 import {
   modalOpenState,
   searchPwEmailState,
@@ -13,7 +13,7 @@ import CloseButton from '../components/CloseButton';
 import DefaultButton from '../components/DefaultButton';
 import DefaultInput from '../components/DefaultInput';
 import MiniButton from '../components/MiniButton';
-import { notiError, notiSuccess } from '../assets/toast';
+import { notiError, notiSuccess, notiInfo } from '../assets/toast';
 
 const Container = styled.div`
   display: flex;
@@ -265,8 +265,7 @@ const LogIn = ({ userMenu }) => {
       }
     });
   };
-  const currentUser = useRecoilValue(currentUserState);
-  console.log(currentUser);
+
   return (
     <Container>
       <div className="login-container" ref={userMenu}>
@@ -348,7 +347,7 @@ const LogIn = ({ userMenu }) => {
           </>
         ) : (
           <div className="image-container">
-            <Authbutton href="">
+            <Authbutton onClick={() => notiInfo('준비 중인 기능입니다!')}>
               <img
                 src={require('../images/google login.png')}
                 alt="구글 로그인"
@@ -360,7 +359,7 @@ const LogIn = ({ userMenu }) => {
                 alt="깃허브 로그인"
               ></img>
             </Authbutton>
-            <Authbutton href="">
+            <Authbutton onClick={() => notiInfo('준비 중인 기능입니다!')}>
               <img
                 src={require('../images/kakao login.png')}
                 alt="카카오톡 로그인"

--- a/client/src/pages/LogIn.js
+++ b/client/src/pages/LogIn.js
@@ -127,12 +127,21 @@ const Container = styled.div`
   }
 `;
 
-const Authbutton = styled.a`
-  margin: 30px;
+const Authbutton = styled.button`
+  height: 60px;
+  width: 60px;
+  border-radius: 30px;
+  background-color: #fff;
+  border: none;
+  margin: 0 60px 0 0;
+
+  :last-child {
+    margin-right: 0;
+  }
 
   img {
-    width: 60px;
-    height: 60px;
+    width: 100%;
+    height: 100%;
   }
 `;
 

--- a/client/src/pages/LogIn.js
+++ b/client/src/pages/LogIn.js
@@ -229,7 +229,10 @@ const LogIn = ({ userMenu }) => {
         .then((res) => {
           localStorage.setItem('Authorization', res.headers.authorization);
           localStorage.setItem('Refresh', res.headers.refresh);
-          setCurrentUser({ memberId: res.headers.memberid, isLogIn: true });
+          setCurrentUser({
+            memberId: Number(res.headers.memberid),
+            isLogIn: true,
+          });
           setEmail('');
           setPassword('');
           closeLogIn();
@@ -256,7 +259,7 @@ const LogIn = ({ userMenu }) => {
       const githubURL = window.localStorage.getItem('githubURL');
 
       if (Authorization) {
-        setCurrentUser({ memberId, isLogIn: true });
+        setCurrentUser({ memberId: Number(memberId), isLogIn: true });
         notiSuccess('로그인 되었습니다!');
       } else if (githubURL) {
         notiError(

--- a/client/src/pages/ReceiveGithub.js
+++ b/client/src/pages/ReceiveGithub.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { AiOutlineCheck } from 'react-icons/ai';
@@ -40,15 +41,22 @@ const ReceiveGithub = () => {
 
   const url = new URL(window.location.href);
   const githubURL = url.searchParams.get('github');
+  const Authorization = url.searchParams.get('Authorization');
+  const Refresh = url.searchParams.get('Refresh');
+  const memberId = url.searchParams.get('memberId');
+
+  if (githubURL) localStorage.setItem('githubURL', githubURL);
+  else if (Authorization) {
+    localStorage.setItem('Authorization', Authorization);
+    localStorage.setItem('Refresh', Refresh);
+    localStorage.setItem('memberId', memberId);
+  }
 
   useEffect(() => {
     if (time === 0) window.close();
-    if (githubURL) {
-      localStorage.setItem('githubURL', githubURL);
-      setInterval(() => {
-        setTime(time - 1);
-      }, 1000);
-    }
+    setInterval(() => {
+      setTime(time - 1);
+    }, 1000);
   }, [time]);
 
   return (

--- a/client/src/pages/ReceiveGithub.js
+++ b/client/src/pages/ReceiveGithub.js
@@ -11,7 +11,10 @@ const Container = styled.div`
   left: 0;
   bottom: 0;
   z-index: 30;
-  padding-top: 100px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   background-color: var(--purple-light);
 

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -291,8 +291,7 @@ const SignUp = () => {
       axios
         .post('/members/signup', signUpInfo)
         .then(() => {
-          // + 입력되어 있던 데이터로 로그인 요청
-          notiSuccess('가입되었습니다'); // 로그인 요청 추가시 환영 문구로 변경 필요
+          notiSuccess('가입되었습니다! 메인페이지에서 로그인을 진행해 주세요!');
           window.location = '/';
           window.localStorage.removeItem('githubURL');
         })


### PR DESCRIPTION
#100 
☺️깃허브 소셜 로그인 기능입니다! 

주요 변경사항 입니다:
- 깃허브 소셜 로그인은 연동 페이지와 같은 로직을 사용해 구현했습니다☺️ 
- ReceiveGithub 페이지에서 등록된 사용자일 경우 깃허브 주소 대신 전달해주는 access/refresh token과 memberID를 로컬 스토리지에 저장할 수 있도록 했습니다!
- 일반 로그인과 달리 memberID도 로컬스토리지에 저장되기 때문에, 로그아웃 부분에서 memberID도 지우는 부분을 추가했습니다.
- 소셜 로그인이 anchor 태그로 되어있어 버튼으로 수정 후 css를 수정했습니다.
