### PR TITLE
Fix: 깃허브 로그인 후 로그인 모달 닫기 

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -46,7 +46,7 @@ function App() {
             <Route path="/mypage/edit/:id" element={<MyPageEdit />} />
             <Route path="/profile/:id" element={<Profile />} />
             <Route path="/signup" element={<SignUp />} />
-            <Route path="/receive-token.html" element={<ReceiveGithub />} />
+            <Route path="/receive-token" element={<ReceiveGithub />} />
           </Routes>
         </ContentContainer>
       </Container>

--- a/client/src/assets/toast.js
+++ b/client/src/assets/toast.js
@@ -34,3 +34,16 @@ export const notiInfo = (message) => {
     confirmButtonText: '확인',
   });
 };
+
+export const notiToast = (title, icon) => {
+  Swal.fire({
+    title: title,
+    icon: icon,
+    toast: true,
+    position: 'top',
+    background: 'white',
+    showConfirmButton: false,
+    timer: 2500,
+    timerProgressBar: true,
+  });
+};

--- a/client/src/pages/LogIn.js
+++ b/client/src/pages/LogIn.js
@@ -234,7 +234,7 @@ const LogIn = ({ userMenu }) => {
           });
           setEmail('');
           setPassword('');
-          notiSuccess('로그인 완료 되었습니다.');
+          notiSuccess('로그인 되었습니다.');
           closeLogIn();
         })
         .catch((ex) => {
@@ -259,10 +259,11 @@ const LogIn = ({ userMenu }) => {
 
       if (Authorization) {
         setCurrentUser({ memberId: Number(memberId), isLogIn: true });
+        closeLogIn();
         notiSuccess('로그인 되었습니다!');
       } else if (githubURL) {
         notiError(
-          '등록된 깃허브 계정이 아닙니다! 회원가입 후 깃허브 계정을 연동해주세요',
+          '등록된 깃허브 계정이 아닙니다! 로그인 후 깃허브 계정을 연결해주세요.',
         );
       }
     });

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -21,7 +21,7 @@ import {
   skillstacksCheckState,
   interestsCheckState,
 } from '../atom/atom';
-import { notiError, notiInfo, notiSuccess } from '../assets/toast';
+import { notiError, notiInfo, notiSuccess, notiToast } from '../assets/toast';
 
 const Container = styled.div`
   min-height: calc(100vh - 62px);
@@ -190,7 +190,7 @@ const SignUp = () => {
   // 아이디 인증하기
   const onCheckIdBtn = () => {
     onIdValidation();
-    if (!userIdErr) {
+    if (!userIdErr && userId.length > 1) {
       axios
         .post(`/members/signup/email-send`, {
           email: userId,
@@ -206,6 +206,8 @@ const SignUp = () => {
             console.log(err);
           }
         });
+    } else {
+      notiToast('이메일 주소를 다시 확인해주세요', 'error');
     }
   };
   // 인증코드 인증확인
@@ -220,7 +222,7 @@ const SignUp = () => {
         setCodeChecked(true);
       })
       .catch(() => {
-        notiError('인증코드가 유효하지 않습니다.');
+        notiToast('인증코드가 유효하지 않습니다.', 'error');
         setVerificationCodeErr(true);
         setCodeChecked(false);
       });
@@ -252,6 +254,9 @@ const SignUp = () => {
       if (githubURL) {
         setGithub(githubURL);
         setGithubChecked(true);
+      } else {
+        const Authorization = window.localStorage.getItem('Authorization');
+        if (Authorization) notiInfo('이미 등록된 깃허브 주소입니다.');
       }
     });
   };


### PR DESCRIPTION
#121 
+ 깃허브 리다이렉트 페이지 라우트 수정: .html제거했습니다!
+ 회원가입 시 이미 등록된 깃허브 계정일 경우 알림창을 띄우도록 했습니다.
+ 토스트 메시지 알림창을 만들어서 회원가입 페이지 일부에 사용했습니다. 